### PR TITLE
fix: vendored module builds and template output

### DIFF
--- a/.changeset/create-bundle-and-shake.md
+++ b/.changeset/create-bundle-and-shake.md
@@ -1,0 +1,5 @@
+---
+"@gwigz/slua-create": patch
+---
+
+single template bundles to one `.slua` output, multi template `build.ts` tree-shakes vendored modules

--- a/.changeset/modules-exclude-tests.md
+++ b/.changeset/modules-exclude-tests.md
@@ -1,0 +1,5 @@
+---
+"@gwigz/slua-modules": patch
+---
+
+exclude test files from the published tarball

--- a/.changeset/modules-yield-fetch-runtime.md
+++ b/.changeset/modules-yield-fetch-runtime.md
@@ -1,0 +1,5 @@
+---
+"@gwigz/slua-modules": patch
+---
+
+fix vendored yield builds, `fetch` now builds the `ll.HTTPRequest` parameter list at runtime instead of relying on the `$httpRequest` inline transform

--- a/.changeset/plugin-custom-header-spread.md
+++ b/.changeset/plugin-custom-header-spread.md
@@ -1,0 +1,5 @@
+---
+"@gwigz/slua-tstl-plugin": patch
+---
+
+spread tuple options like `customHeader` into the flat parameter list instead of emitting a nested table

--- a/.changeset/prepack-builds.md
+++ b/.changeset/prepack-builds.md
@@ -1,0 +1,6 @@
+---
+"@gwigz/slua-tstl-plugin": patch
+"@gwigz/slua-json": patch
+---
+
+add prepack scripts so packing always builds fresh output

--- a/apps/web/content/docs/create/templates.mdx
+++ b/apps/web/content/docs/create/templates.mdx
@@ -6,12 +6,14 @@ description: Available project templates and optional extras
 ## Single Script
 
 The `single` template produces the simplest possible project layout, one
-`main.ts` file that compiles to a single `.slua` output via TSTL.
+`new-script.ts` file at the project root that compiles to a single flat
+`out/new-script.slua` via TSTL. Imports (including vendored modules) are
+bundled into that one output file.
 
 ```
 my-project/
-├── src/
-│   └── main.ts
+├── modules/          (when config or yield extras are selected)
+├── new-script.ts
 ├── package.json
 └── tsconfig.json
 ```
@@ -48,8 +50,13 @@ my-project/
 └── tsconfig.json
 ```
 
+The scaffold ships one `src/new-script/index.ts` entry point; add more by
+listing them in the `SCRIPTS` array in `build.ts`.
+
 `build.ts` uses the TSTL API directly to compile each entry point with its
-own output path.
+own output path. Before transpiling, it tree-shakes vendored module source
+via `@gwigz/slua-tstl-plugin/shake`, so unused module exports never reach
+the `.slua` output.
 
 ## Optional Extras
 
@@ -67,8 +74,9 @@ Compile-time flags are pre-wired on the transpiler plugin config.
 
 ### StyLua Formatting
 
-Adds a `.stylua.toml` config to your project so you can auto-format compiled
-`.slua` output with [StyLua](https://github.com/JohnnyMorganz/StyLua).
+Adds [StyLua](https://github.com/JohnnyMorganz/StyLua) so compiled `.slua`
+output can be auto-formatted, via a `format` script in single-script
+projects and as a build step in multi-script ones.
 
 ### Linting (`oxlint`)
 

--- a/apps/web/content/docs/create/usage.mdx
+++ b/apps/web/content/docs/create/usage.mdx
@@ -31,7 +31,7 @@ npx @gwigz/slua-create ./my-project
 The CLI walks you through the following steps:
 
 1. **Project directory** where to create the project (skipped if a positional argument is given)
-2. **Template** choose between `single` (one `main.ts`) or `multi` (custom `build.ts` with multiple entry points)
+2. **Template** choose between `single` (one `new-script.ts`) or `multi` (custom `build.ts` with multiple entry points)
 3. **Extras** optional add-ons (see below)
 4. **Git** whether to initialize a Git repository
 5. **Install packages** whether to run the package manager install automatically

--- a/apps/web/content/docs/slua/transpiler-plugin.mdx
+++ b/apps/web/content/docs/slua/transpiler-plugin.mdx
@@ -261,6 +261,22 @@ local id = ll.HTTPRequest("https://example.com", {
 }, payload)
 ```
 
+Tuple-valued params like `customHeader` are written as inline array literals
+and spread into the flat list:
+
+```typescript
+const id = $httpRequest("https://example.com", {
+  customHeader: ["X-Key", "abc"],
+})
+```
+
+```lua
+local id = ll.HTTPRequest("https://example.com", {
+    HTTP_CUSTOM_HEADER, "X-Key", "abc",
+    HTTP_METHOD, "GET"
+}, "")
+```
+
 ### Typed getter returns
 
 Functions like `ll.GetObjectDetails`, `ll.GetParcelDetails`, `ll.GetPrimitiveParams`, `ll.GetEnvironment`, `ll.GetPrimMediaParams`, `ll.GetLinkMedia`, and `ll.ParcelMediaQuery` accept an array of flag constants and return a corresponding list of values. The type definitions map each flag to its return type, so destructuring gives you fully typed results:

--- a/packages/create/src/templates/multi.ts
+++ b/packages/create/src/templates/multi.ts
@@ -26,6 +26,7 @@ export function generateMultiTemplate(options: ProjectOptions): Record<string, s
     "@gwigz/tstl-bundle-flatten": VERSIONS["@gwigz/tstl-bundle-flatten"],
     "@typescript-to-lua/language-extensions": VERSIONS["@typescript-to-lua/language-extensions"],
     "@types/node": VERSIONS["@types/node"],
+    rollup: VERSIONS["rollup"],
     typescript: VERSIONS["typescript"],
     "typescript-to-lua": VERSIONS["typescript-to-lua"],
   }
@@ -139,7 +140,11 @@ export function generateMultiTemplate(options: ProjectOptions): Record<string, s
   Object.assign(files, vendoredModuleFiles(extras, "src/modules/"))
 
   if (extras.linting) {
-    files[".oxlintrc.json"] = oxlintrcContent(["build.ts"])
+    // Vendored src/modules/ is module source the user shouldn't have to lint
+    files[".oxlintrc.json"] = oxlintrcContent([
+      "build.ts",
+      ...(extras.config || extras.yield ? ["src/modules/"] : []),
+    ])
   }
 
   if (extras.formatting) {

--- a/packages/create/src/templates/single.ts
+++ b/packages/create/src/templates/single.ts
@@ -20,6 +20,7 @@ export function generateSingleTemplate(options: ProjectOptions): Record<string, 
   const devDependencies: Record<string, string> = {
     "@gwigz/slua-tstl-plugin": VERSIONS["@gwigz/slua-tstl-plugin"],
     "@gwigz/slua-types": VERSIONS["@gwigz/slua-types"],
+    "@gwigz/tstl-bundle-flatten": VERSIONS["@gwigz/tstl-bundle-flatten"],
     "@typescript-to-lua/language-extensions": VERSIONS["@typescript-to-lua/language-extensions"],
     typescript: VERSIONS["typescript"],
     "typescript-to-lua": VERSIONS["typescript-to-lua"],
@@ -99,7 +100,10 @@ export function generateSingleTemplate(options: ProjectOptions): Record<string, 
     pluginEntry.define = define
   }
 
-  const luaPlugins: Record<string, unknown>[] = [pluginEntry]
+  const luaPlugins: Record<string, unknown>[] = [
+    pluginEntry,
+    { name: "@gwigz/tstl-bundle-flatten" },
+  ]
 
   const includes: string[] = [`new-script.${ext}`, ...moduleFlagsFiles(extras, "modules/")]
 
@@ -110,6 +114,8 @@ export function generateSingleTemplate(options: ProjectOptions): Record<string, 
     tstl: {
       luaTarget: "Luau",
       luaLibImport: "inline",
+      luaBundle: "new-script.slua",
+      luaBundleEntry: `new-script.${ext}`,
       noImplicitSelf: true,
       noImplicitGlobalVariables: true,
       luaPlugins,

--- a/packages/create/src/templates/snippets.ts
+++ b/packages/create/src/templates/snippets.ts
@@ -114,7 +114,8 @@ export function buildTsContent(extras: Extras, packageManager: string): string {
     '/// <reference types="node" />',
     'import ts, { type Diagnostic } from "typescript"',
     'import * as tstl from "typescript-to-lua"',
-    'import { watch, readFileSync, writeFileSync } from "node:fs"',
+    'import { shakeModules, stripDeadExports } from "@gwigz/slua-tstl-plugin/shake"',
+    'import { watch, readFileSync } from "node:fs"',
   ]
 
   if (extras.stylua) {
@@ -139,9 +140,14 @@ ${defineEntries.map((entry) => `        ${entry},`).join("\n")}
   }
 
   const fileEntries = [
-    `resolve(\`src/\${script}/index.${ext}\`)`,
+    "entry",
     ...moduleFlagsFiles(extras, "src/modules/").map((file) => `resolve("${file}")`),
   ]
+
+  const filesLine =
+    fileEntries.length > 1
+      ? `const files = [\n${fileEntries.map((entry) => `      ${entry},`).join("\n")}\n    ]`
+      : `const files = [${fileEntries.join(", ")}]`
 
   const jsxOptions = extras.jsx
     ? `
@@ -222,39 +228,66 @@ function reportDiagnostics(diagnostics: readonly Diagnostic[]) {
   return hasErrors
 }
 
-function build() {
+// Tree-shakes vendored modules, returns stripped sources keyed by file path
+async function shake(entry: string) {
+  const shaken = new Map<string, string>()
+
+  try {
+    const result = await shakeModules({ entry: [entry], tsconfig: resolve("tsconfig.json") })
+
+    for (const [file, surviving] of result.survivingExports) {
+      shaken.set(resolve(file), stripDeadExports(readFileSync(file, "utf8"), surviving))
+    }
+  } catch (error) {
+    console.warn("warning: tree-shaking skipped:", error instanceof Error ? error.message : error)
+  }
+
+  return shaken
+}
+
+async function build() {
   let hasErrors = false
 
   for (const script of SCRIPTS) {
-    const files = [${fileEntries.join(", ")}]
+    const entry = resolve(\`src/\${script}/index.${ext}\`)
+    ${filesLine}
 
-    const result = tstl.transpileFiles(files, {
+    const options: tstl.CompilerOptions = {
       ...BASE_OPTIONS,
       luaBundle: \`\${script}.slua\`,
-      luaBundleEntry: resolve(\`src/\${script}/index.${ext}\`),
-    })
+      luaBundleEntry: entry,
+    }
 
-    if (reportDiagnostics(result.diagnostics)) {
+    const shaken = await shake(entry)
+    const host = ts.createCompilerHost(options)
+    const readSourceFile = host.getSourceFile.bind(host)
+
+    host.getSourceFile = (fileName, languageVersion, ...args) => {
+      const stripped = shaken.get(resolve(fileName))
+
+      if (stripped !== undefined) {
+        return ts.createSourceFile(fileName, stripped, languageVersion, true)
+      }
+
+      return readSourceFile(fileName, languageVersion, ...args)
+    }
+
+    const program = ts.createProgram(files, options, host)
+    const result = new tstl.Transpiler().emit({ program })
+
+    if (reportDiagnostics([...ts.getPreEmitDiagnostics(program), ...result.diagnostics])) {
       hasErrors = true
     }
   }
 
-  if (hasErrors) return false
-
-  // Prepend generated header to each output file
-  for (const distFile of DIST_FILES) {
-    const filePath = resolve(distFile)
-    const content = readFileSync(filePath, "utf8")
-
-    writeFileSync(filePath, content)
-  }${styluaBlock}
+  if (hasErrors) return false${styluaBlock}
 
   console.log(\`Built \${DIST_FILES.join(", ")}\`)
 
   return true
 }
 
-if (!build() && !WATCH) {
+if (!(await build()) && !WATCH) {
   process.exit(1)
 }
 
@@ -262,6 +295,7 @@ if (WATCH) {
   console.log("Watching src/ for changes...")
 
   let debounce: ReturnType<typeof setTimeout> | null = null
+  let pending: Promise<unknown> = Promise.resolve()
 
   watch(resolve("src"), { recursive: true }, (_event: string, filename: string | null) => {
 ${watchFilter}
@@ -271,7 +305,7 @@ ${watchFilter}
     debounce = setTimeout(() => {
       debounce = null
       console.log(\`\\nRebuilding...\`)
-      build()
+      pending = pending.then(() => build())
     }, 50)
   })
 }

--- a/packages/create/src/templates/versions.ts
+++ b/packages/create/src/templates/versions.ts
@@ -8,6 +8,7 @@ export const VERSIONS = {
   "@gwigz/jsx-inline": "^1.1.0",
   "@johnnymorganz/stylua-bin": "^2.5.2",
   "@types/node": "^25.5.0",
+  rollup: "^4.62.2",
   tsx: "^4.23.12",
   "@gwigz/slua-oxlint-config": "^0.2.0",
   "oxlint-plugin-eslint": "^1.78.0",

--- a/packages/json/package.json
+++ b/packages/json/package.json
@@ -23,6 +23,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "test": "bun test"
+    "test": "bun test",
+    "prepack": "tsc"
   }
 }

--- a/packages/modules/package.json
+++ b/packages/modules/package.json
@@ -11,6 +11,7 @@
   "bin": "dist/index.js",
   "files": [
     "src",
+    "!src/**/*.test.ts",
     "dist"
   ],
   "type": "module",

--- a/packages/modules/src/testing/index.ts
+++ b/packages/modules/src/testing/index.ts
@@ -286,9 +286,18 @@ const GLOBAL_KEYS = [
   "YIELD_KV",
   "YIELD_DIALOG",
   "YIELD_HTTP",
-  "$httpRequest",
   "YIELD_PERMISSIONS",
   "YIELD_SENSOR",
+  "HTTP_METHOD",
+  "HTTP_MIMETYPE",
+  "HTTP_BODY_MAXLENGTH",
+  "HTTP_VERIFY_CERT",
+  "HTTP_VERBOSE_THROTTLE",
+  "HTTP_CUSTOM_HEADER",
+  "HTTP_PRAGMA_NO_CACHE",
+  "HTTP_USER_AGENT",
+  "HTTP_ACCEPT",
+  "HTTP_EXTENDED_ERROR",
 ] as const
 
 const savedGlobals: Record<string, any> = {}
@@ -337,6 +346,16 @@ export function setup(): void {
   g.YIELD_HTTP = true
   g.YIELD_PERMISSIONS = true
   g.YIELD_SENSOR = true
+  g.HTTP_METHOD = 0
+  g.HTTP_MIMETYPE = 1
+  g.HTTP_BODY_MAXLENGTH = 2
+  g.HTTP_VERIFY_CERT = 3
+  g.HTTP_VERBOSE_THROTTLE = 4
+  g.HTTP_CUSTOM_HEADER = 5
+  g.HTTP_PRAGMA_NO_CACHE = 6
+  g.HTTP_USER_AGENT = 7
+  g.HTTP_ACCEPT = 8
+  g.HTTP_EXTENDED_ERROR = 9
 }
 
 /**

--- a/packages/modules/src/yield/index.test.ts
+++ b/packages/modules/src/yield/index.test.ts
@@ -521,12 +521,45 @@ describe("textBox", () => {
 describe("fetch", () => {
   it("yields and returns response object", () => {
     spyOn(g.coroutine, "running").mockReturnValue({ __mock: true })
-    g.$httpRequest = () => "req-http"
+
+    let captured: { url: string; params: unknown[]; body: string } | undefined
+
+    g.ll.HTTPRequest = (url: string, params: unknown[], body: string) => {
+      captured = { url, params, body }
+
+      return "req-http"
+    }
 
     setCoroutineYieldValue([true, { status: 200, metadata: [], body: "OK" }])
     const result = fetch("https://example.com", { timeout: 30 }) as any
 
     expect(result).toEqual([true, { status: 200, metadata: [], body: "OK" }])
+    expect(captured).toEqual({ url: "https://example.com", params: [0, "GET"], body: "" })
+  })
+
+  it("builds the parameter list from options", () => {
+    spyOn(g.coroutine, "running").mockReturnValue({ __mock: true })
+
+    let captured: { params: unknown[]; body: string } | undefined
+
+    g.ll.HTTPRequest = (_url: string, params: unknown[], body: string) => {
+      captured = { params, body }
+
+      return "req-http"
+    }
+
+    setCoroutineYieldValue([true, { status: 200, metadata: [], body: "OK" }])
+    fetch("https://example.com", {
+      method: "POST",
+      customHeader: ["X-Key", "abc"],
+      body: "payload",
+      timeout: 30,
+    })
+
+    expect(captured).toEqual({
+      params: [0, "POST", 5, "X-Key", "abc"],
+      body: "payload",
+    })
   })
 
   it("handler filters by request ID", () => {
@@ -534,7 +567,7 @@ describe("fetch", () => {
     spyOn(g.coroutine, "running").mockReturnValue(co)
     const resumeSpy = spyOn(g.coroutine, "resume")
 
-    g.$httpRequest = () => "req-http"
+    g.ll.HTTPRequest = () => "req-http"
 
     setCoroutineYieldValue([true, { status: 200, metadata: [], body: "OK" }])
     fetch("https://example.com", { timeout: 30 })
@@ -553,7 +586,7 @@ describe("fetch", () => {
     spyOn(g.coroutine, "running").mockReturnValue(co)
     const resumeSpy = spyOn(g.coroutine, "resume")
 
-    g.$httpRequest = () => "req-http"
+    g.ll.HTTPRequest = () => "req-http"
 
     setCoroutineYieldValue([false, "timeout"])
     fetch("https://example.com", { timeout: 30 })

--- a/packages/modules/src/yield/index.ts
+++ b/packages/modules/src/yield/index.ts
@@ -416,7 +416,59 @@ function yieldFetch(
   let resolved = false
   const timeout = options.timeout
 
-  const requestId = $httpRequest(url, options)
+  // Built at runtime, so the $httpRequest inline transform can't be used here.
+  const params: (string | number)[] = []
+
+  params.push(HTTP_METHOD)
+  params.push(options.method ?? "GET")
+
+  if (options.mimetype !== undefined) {
+    params.push(HTTP_MIMETYPE)
+    params.push(options.mimetype)
+  }
+
+  if (options.bodyMaxlength !== undefined) {
+    params.push(HTTP_BODY_MAXLENGTH)
+    params.push(options.bodyMaxlength)
+  }
+
+  if (options.verifyCert !== undefined) {
+    params.push(HTTP_VERIFY_CERT)
+    params.push(options.verifyCert)
+  }
+
+  if (options.verboseThrottle !== undefined) {
+    params.push(HTTP_VERBOSE_THROTTLE)
+    params.push(options.verboseThrottle)
+  }
+
+  if (options.customHeader !== undefined) {
+    params.push(HTTP_CUSTOM_HEADER)
+    params.push(options.customHeader[0])
+    params.push(options.customHeader[1])
+  }
+
+  if (options.pragmaNoCache !== undefined) {
+    params.push(HTTP_PRAGMA_NO_CACHE)
+    params.push(options.pragmaNoCache)
+  }
+
+  if (options.userAgent !== undefined) {
+    params.push(HTTP_USER_AGENT)
+    params.push(options.userAgent)
+  }
+
+  if (options.accept !== undefined) {
+    params.push(HTTP_ACCEPT)
+    params.push(options.accept)
+  }
+
+  if (options.extendedError !== undefined) {
+    params.push(HTTP_EXTENDED_ERROR)
+    params.push(options.extendedError)
+  }
+
+  const requestId = ll.HTTPRequest(url, params as [], options.body ?? "")
 
   const handler = LLEvents.on(
     "http_response",

--- a/packages/tstl-plugin/package.json
+++ b/packages/tstl-plugin/package.json
@@ -29,7 +29,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "test": "bun test"
+    "test": "bun test",
+    "prepack": "tsc"
   },
   "dependencies": {
     "@gwigz/slua-types": "^1.4.1",

--- a/packages/tstl-plugin/src/__tests__/builder.test.ts
+++ b/packages/tstl-plugin/src/__tests__/builder.test.ts
@@ -169,6 +169,27 @@ describe("options-object transform", () => {
     expect(lua).toContain('""')
   })
 
+  it("httpRequest spreads customHeader tuple into the flat list", () => {
+    const lua = transpile(`
+      const id = $httpRequest("https://example.com", {
+        customHeader: ["X-Key", "abc"],
+      })
+    `)
+
+    expect(lua).toContain("ll.HTTPRequest")
+    expect(lua).toMatch(/HTTP_CUSTOM_HEADER,\s*"X-Key",\s*"abc"/)
+    expect(lua).not.toContain('{"X-Key"')
+  })
+
+  it("httpRequest bails on non-literal customHeader", () => {
+    const lua = transpile(`
+      declare const header: [string, string]
+      const id = $httpRequest("https://example.com", { customHeader: header })
+    `)
+
+    expect(lua).not.toContain("ll.HTTPRequest")
+  })
+
   it("dataFlags with constant", () => {
     const lua = transpile(`
       declare const start: Vector, end_: Vector

--- a/packages/tstl-plugin/src/options-transform.ts
+++ b/packages/tstl-plugin/src/options-transform.ts
@@ -91,6 +91,26 @@ export function emitOptionsCall(
       return context.superTransformExpression(match.rootCall)
     }
 
+    if (methodDef.argCount > 1) {
+      // Tuple-valued params (e.g. customHeader) must be inline array literals
+      // so their values can be spread into the flat list.
+      if (
+        !ts.isArrayLiteralExpression(value) ||
+        value.elements.length !== methodDef.argCount ||
+        value.elements.some((element) => ts.isSpreadElement(element))
+      ) {
+        return context.superTransformExpression(match.rootCall)
+      }
+
+      listElements.push(tstl.createIdentifier(methodDef.constant))
+
+      for (const element of value.elements) {
+        listElements.push(context.transformExpression(element))
+      }
+
+      continue
+    }
+
     listElements.push(tstl.createIdentifier(methodDef.constant))
     listElements.push(context.transformExpression(value))
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Single-script projects now produce bundled `.slua` output.
  - Multi-script builds reduce unused vendored modules through tree-shaking.
  - HTTP requests support runtime options including methods, headers, bodies, caching, and user-agent settings.
  - Tuple options such as custom headers are correctly flattened into request parameters.

- **Bug Fixes**
  - Improved vendored yield builds and HTTP request generation.
  - Published packages now exclude test files and generate fresh build output.

- **Documentation**
  - Updated template, usage, and HTTP request documentation for the new workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->