### PR TITLE
feat: support for client diagnostics rename & item-based events (#115)

### DIFF
--- a/apps/web/content/docs/viewer-client/cli.mdx
+++ b/apps/web/content/docs/viewer-client/cli.mdx
@@ -106,8 +106,9 @@ while you publish one from the viewer.
 The viewer forwards every published object's output to every connection, so
 `--object` narrows the stream to the one you named, matching against each prim
 in its linkset. `--targets` narrows it further, to the items your `slua.json`
-targets deploy to, which needs a viewer that names the item its output came
-from.
+targets deploy to, which needs a viewer that advertises `unifiedDiagnostics`
+and so sends an item reference with each event. Against an older viewer there
+is nothing to filter on, so `logs` warns once and shows everything.
 
 Runtime positions point at the generated Lua (`lua_script:5`), so each line is
 annotated with the TypeScript it maps to, using the source maps of the targets

--- a/apps/web/content/docs/viewer-client/cli.mdx
+++ b/apps/web/content/docs/viewer-client/cli.mdx
@@ -107,6 +107,11 @@ Runtime positions point at the generated Lua (`lua_script:5`), so each line is
 annotated with the TypeScript it maps to, using the source maps of the targets
 in your `slua.json`.
 
+Each line is labelled `object/item`, the same addressing `pull` and `push`
+take, and output a script sent with `llOwnerSay` is tagged `say` rather than
+`debug`. Both need a viewer new enough to send an item reference with its
+runtime events.
+
 ```bash
 slua-viewer logs --object 4f2b0c1e-... --follow
 ```
@@ -174,9 +179,9 @@ against the generated output instead, and the CLI says so.
 Mapping is line accurate, not column accurate. LSL compile errors carry real
 column numbers, which the Luau compiler does not report.
 
-`logs` maps too. Nothing in the viewer's runtime output names the script that
-produced it, so when more than one target's map covers a line, every candidate
-is shown with its target name.
+`logs` maps too. A viewer that names the item its output came from narrows
+that to the target deploying it; without one, a line covered by more than one
+target's map is shown against every candidate, with its target name.
 
 ## JSON output
 

--- a/apps/web/content/docs/viewer-client/cli.mdx
+++ b/apps/web/content/docs/viewer-client/cli.mdx
@@ -103,6 +103,12 @@ Runtime output is only forwarded for published objects, so pass `--object` with
 a UUID to have one published on demand, or `--wait` to hold the connection open
 while you publish one from the viewer.
 
+The viewer forwards every published object's output to every connection, so
+`--object` narrows the stream to the one you named, matching against each prim
+in its linkset. `--targets` narrows it further, to the items your `slua.json`
+targets deploy to, which needs a viewer that names the item its output came
+from.
+
 Runtime positions point at the generated Lua (`lua_script:5`), so each line is
 annotated with the TypeScript it maps to, using the source maps of the targets
 in your `slua.json`.
@@ -158,6 +164,7 @@ description key needs the object published from the viewer first, see
 | `--file <path>`       | `push`, `link` | File to push, or to record when linking              |
 | `--key <key>`         | `link`         | Description key to pair on, default `slua:<name>`    |
 | `-f`, `--follow`      | `logs`         | Keep streaming, reconnecting if the viewer restarts  |
+| `--targets`           | `logs`         | Only output from items your `slua.json` targets      |
 | `--wait`              | most           | Hold the viewer connection open until it publishes   |
 | `--port <port>`       | all            | Viewer websocket port, default `9020`                |
 | `--timeout <ms>`      | all            | Request timeout                                      |

--- a/apps/web/content/docs/viewer-client/index.mdx
+++ b/apps/web/content/docs/viewer-client/index.mdx
@@ -7,7 +7,7 @@ icon: BookOpen
 import { Cards, Card } from "fumadocs-ui/components/card"
 import { Terminal, Crosshair, Code2 } from "lucide-react"
 
-<Callout type="warn" title="Work in Progress">
+<Callout type="warn" title="Work in progress">
   This package is new and the viewer's external editing protocol is still changing. Expect rough
   edges, and pin the version once a deploy depends on it.
 </Callout>

--- a/apps/web/content/docs/viewer-client/library.mdx
+++ b/apps/web/content/docs/viewer-client/library.mdx
@@ -24,7 +24,7 @@ bun add -d @gwigz/slua-viewer-client
 ```ts
 import { readFile } from "node:fs/promises"
 import {
-  parseCompileErrors,
+  diagnosticsFrom,
   parseObjectRef,
   resolveItem,
   ViewerClient,
@@ -43,7 +43,7 @@ try {
   })
 
   if (result.compiled === false) {
-    console.error(parseCompileErrors(result.errors, "luau"))
+    console.error(diagnosticsFrom(result, "luau"))
   }
 } finally {
   // An open socket keeps the process alive, so this happens either way.
@@ -88,8 +88,10 @@ client.on("runtime.error", (event) => console.error(event.objectName, event.mess
 ```
 
 `on` returns an unsubscribe function, and `runtime.debug` carries the script's
-non-error output. `runtime.error` currently arrives with `error` and `line`
-empty, and the viewer sends the text as a separate `runtime.debug` message.
+non-error output. A viewer advertising the `unifiedDiagnostics` feature fills in
+`error`, `line` and an `item` reference naming the script; older ones leave
+`error` and `line` empty and send the text as a separate `runtime.debug`
+message.
 
 `ensurePublished` and `resolveItem` take options for the two things the viewer
 makes awkward:

--- a/apps/web/content/docs/viewer-client/library.mdx
+++ b/apps/web/content/docs/viewer-client/library.mdx
@@ -90,8 +90,8 @@ client.on("runtime.error", (event) => console.error(event.objectName, event.mess
 `on` returns an unsubscribe function, and `runtime.debug` carries the script's
 non-error output. A viewer advertising the `unifiedDiagnostics` feature fills in
 `error`, `line` and an `item` reference naming the script; older ones leave
-`error` and `line` empty and send the text as a separate `runtime.debug`
-message.
+`error` empty and `line` 0, and send the text as a separate `runtime.debug`
+message. `line` is 0 on any viewer when the error names no line.
 
 `ensurePublished` and `resolveItem` take options for the two things the viewer
 makes awkward:

--- a/packages/oxlint-config/rules.test.ts
+++ b/packages/oxlint-config/rules.test.ts
@@ -1,10 +1,18 @@
 import { describe, it, expect } from "bun:test"
 import { execSync } from "node:child_process"
-import { writeFileSync, unlinkSync } from "node:fs"
+import { existsSync, writeFileSync, unlinkSync } from "node:fs"
 import { resolve } from "node:path"
 
 const CONFIG = resolve(import.meta.dir, ".oxlintrc.json")
 const TMP = resolve(import.meta.dir, "__test_fixture.ts")
+
+// Every case shells out, and npx resolving the binary each time costs more
+// than the lint it is there to run, enough for the first case to time out.
+const OXLINT =
+  [
+    resolve(import.meta.dir, "node_modules/.bin/oxlint"),
+    resolve(import.meta.dir, "../../node_modules/.bin/oxlint"),
+  ].find((path) => existsSync(path)) ?? "npx oxlint"
 
 interface Diagnostic {
   message: string
@@ -16,7 +24,7 @@ function lint(code: string): Diagnostic[] {
   writeFileSync(TMP, code)
 
   try {
-    const out = execSync(`npx oxlint --config ${CONFIG} --format json ${TMP}`, {
+    const out = execSync(`${OXLINT} --config ${CONFIG} --format json ${TMP}`, {
       encoding: "utf-8",
       stdio: ["pipe", "pipe", "pipe"],
     })

--- a/packages/oxlint-config/rules.test.ts
+++ b/packages/oxlint-config/rules.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "bun:test"
-import { execSync } from "node:child_process"
+import { execFileSync } from "node:child_process"
 import { existsSync, writeFileSync, unlinkSync } from "node:fs"
+import { platform } from "node:os"
 import { resolve } from "node:path"
 
 const CONFIG = resolve(import.meta.dir, ".oxlintrc.json")
@@ -8,11 +9,14 @@ const TMP = resolve(import.meta.dir, "__test_fixture.ts")
 
 // Every case shells out, and npx resolving the binary each time costs more
 // than the lint it is there to run, enough for the first case to time out.
-const OXLINT =
-  [
-    resolve(import.meta.dir, "node_modules/.bin/oxlint"),
-    resolve(import.meta.dir, "../../node_modules/.bin/oxlint"),
-  ].find((path) => existsSync(path)) ?? "npx oxlint"
+const INSTALLED = [
+  resolve(import.meta.dir, "node_modules/.bin/oxlint"),
+  resolve(import.meta.dir, "../../node_modules/.bin/oxlint"),
+].find((path) => existsSync(path))
+
+const [OXLINT, ARGV0] = INSTALLED
+  ? [INSTALLED, []]
+  : [platform() === "win32" ? "npx.cmd" : "npx", ["oxlint"]]
 
 interface Diagnostic {
   message: string
@@ -24,7 +28,9 @@ function lint(code: string): Diagnostic[] {
   writeFileSync(TMP, code)
 
   try {
-    const out = execSync(`${OXLINT} --config ${CONFIG} --format json ${TMP}`, {
+    // Argument array rather than a command line, so a checkout path with a
+    // space in it is one argument rather than two.
+    const out = execFileSync(OXLINT, [...ARGV0, "--config", CONFIG, "--format", "json", TMP], {
       encoding: "utf-8",
       stdio: ["pipe", "pipe", "pipe"],
     })

--- a/packages/viewer-client/README.md
+++ b/packages/viewer-client/README.md
@@ -213,7 +213,7 @@ Only field-shaped keys convert. Keys carrying data, an item named `Main` or an o
 ```ts
 import { readFile } from "node:fs/promises"
 import {
-  parseCompileErrors,
+  diagnosticsFrom,
   parseObjectRef,
   resolveItem,
   ViewerClient,
@@ -232,7 +232,7 @@ try {
   })
 
   if (result.compiled === false) {
-    console.error(parseCompileErrors(result.errors, "luau"))
+    console.error(diagnosticsFrom(result, "luau"))
   }
 } finally {
   // An open socket keeps the process alive, so this happens either way.

--- a/packages/viewer-client/README.md
+++ b/packages/viewer-client/README.md
@@ -93,6 +93,7 @@ slua-viewer push dist/main.slua "My Rezzer/Panel/Main"
 | `--file <path>`       | `push`, `link` | File to push, or to record when linking              |
 | `--key <key>`         | `link`         | Description key to pair on, default `slua:<name>`    |
 | `-f`, `--follow`      | `logs`         | Keep streaming, reconnecting if the viewer restarts  |
+| `--targets`           | `logs`         | Only output from items your `slua.json` targets      |
 | `--wait`              | most           | Hold the viewer connection open until it publishes   |
 | `--port <port>`       | all            | Viewer websocket port, default `9020`                |
 | `--timeout <ms>`      | all            | Request timeout                                      |

--- a/packages/viewer-client/README.md
+++ b/packages/viewer-client/README.md
@@ -198,7 +198,7 @@ An object sitting in your own inventory cannot be reached at all. It has to be r
 
 `push` looks for a source map beside the file it uploads (`dist/main.slua.map`) and translates the viewer's Lua line numbers back to your original source. Enable it with `"sourceMap": true` in your tsconfig. Without a map, errors are reported against the generated output instead.
 
-`logs` maps too. Runtime output reports positions in the generated Lua (`lua_script:5`), so each line is annotated with the TypeScript it came from, using the source maps of the targets in your `slua.json`. Nothing in the output names the script that produced it, so when more than one target's map covers a line, every candidate is shown with its target name.
+`logs` maps too. Runtime output reports positions in the generated Lua (`lua_script:5`), so each line is annotated with the TypeScript it came from, using the source maps of the targets in your `slua.json`. A viewer that names the item its output came from narrows that to the target deploying it, and labels each line `object/item`; without one, a line covered by more than one target's map is shown against every candidate, with its target name.
 
 If you bundle with `@gwigz/tstl-bundle-flatten`, you need 1.2.0 or newer. Earlier versions rewrote the emitted Lua without updating the map, leaving it describing the unflattened bundle. Mapping is line accurate, not column accurate.
 

--- a/packages/viewer-client/src/cli/args.test.ts
+++ b/packages/viewer-client/src/cli/args.test.ts
@@ -140,6 +140,16 @@ describe("parseCliArgs", () => {
       name: "logs",
       object: "O",
       follow: true,
+      targets: false,
+    })
+  })
+
+  it("parses the logs target filter", () => {
+    expect(parseCliArgs(["logs", "--targets"]).command).toEqual({
+      name: "logs",
+      object: undefined,
+      follow: false,
+      targets: true,
     })
   })
 

--- a/packages/viewer-client/src/cli/args.test.ts
+++ b/packages/viewer-client/src/cli/args.test.ts
@@ -201,6 +201,7 @@ describe("helpText", () => {
       "--file",
       "--key",
       "--follow",
+      "--targets",
       "--wait",
       "--port",
       "--timeout",

--- a/packages/viewer-client/src/cli/args.ts
+++ b/packages/viewer-client/src/cli/args.ts
@@ -42,7 +42,7 @@ export type Command =
   | { name: "link"; target: string; object?: string; item?: string; file?: string; key?: string }
   | { name: "reset"; ref: ObjectRef }
   | { name: "set-running"; ref: ObjectRef; running: boolean }
-  | { name: "logs"; object?: string; follow: boolean }
+  | { name: "logs"; object?: string; follow: boolean; targets: boolean }
   | { name: "syntax"; kind?: SyntaxKind }
 
 export interface CliArgs {
@@ -67,6 +67,7 @@ const OPTIONS = {
   file: { type: "string" },
   key: { type: "string" },
   follow: { type: "boolean", short: "f" },
+  targets: { type: "boolean" },
   wait: { type: "boolean" },
   help: { type: "boolean", short: "h" },
   version: { type: "boolean", short: "v" },
@@ -235,7 +236,12 @@ export function parseCliArgs(argv: string[]): CliArgs {
     case "logs":
       return {
         global,
-        command: { name: "logs", object: values.object, follow: values.follow === true },
+        command: {
+          name: "logs",
+          object: values.object,
+          follow: values.follow === true,
+          targets: values.targets === true,
+        },
       }
 
     case "syntax": {
@@ -307,6 +313,7 @@ Options
   --file <path>        File to push, or to record when linking
   --key <key>          Description key to pair on (default slua:<name>)
   -f, --follow         Keep streaming (logs)
+  --targets            Only output from items your slua.json targets (logs)
   --wait               Wait for the viewer to publish, so "Explore in IDE"
                        has a client to publish to
   --port <port>        Viewer websocket port (default ${DEFAULT_PORT})
@@ -323,5 +330,6 @@ Examples
   slua-viewer link main
   slua-viewer push --all
   slua-viewer logs --object 4f2b... --follow
+  slua-viewer logs --targets --follow
 `
 }

--- a/packages/viewer-client/src/cli/commands/logs.test.ts
+++ b/packages/viewer-client/src/cli/commands/logs.test.ts
@@ -43,6 +43,15 @@ describe("runtimeText", () => {
     )
   })
 
+  it("keeps a column the text cannot carry, next to a line it already names", () => {
+    expect(
+      runtimeText(
+        { ...event, message: "lua_script:4: boom", error: "", line: 4, column: 7 },
+        "error",
+      ),
+    ).toBe("lua_script:4: boom (column 7)")
+  })
+
   it("keeps a line number the text does not already carry", () => {
     expect(runtimeText({ ...event, message: "boom", error: "", line: 4 }, "error")).toBe(
       "boom (line 4)",

--- a/packages/viewer-client/src/cli/commands/logs.test.ts
+++ b/packages/viewer-client/src/cli/commands/logs.test.ts
@@ -11,6 +11,7 @@ import {
   runtimeText,
   sourceName,
   tagFor,
+  wantedEvent,
   withUpdate,
 } from "./logs"
 
@@ -221,5 +222,65 @@ describe("namesTarget", () => {
 
   it("keeps output a viewer sent without an item, which cannot be judged", () => {
     expect(namesTarget(event, items)).toBe(true)
+  })
+})
+
+describe("wantedEvent", () => {
+  const ids = new Set(["root", "child"])
+  const items = new Set(["main"])
+
+  it("keeps everything when no object and no target filter was asked for", () => {
+    expect(wantedEvent({ ...event, objectId: "elsewhere" }, {}, undefined, items)).toBe(true)
+  })
+
+  it("holds output back until the named object resolves", () => {
+    expect(
+      wantedEvent({ ...event, objectId: "elsewhere" }, { object: "O" }, undefined, items),
+    ).toBe(false)
+
+    expect(wantedEvent({ ...event, objectId: "root" }, { object: "O" }, undefined, items)).toBe(
+      false,
+    )
+  })
+
+  it("filters on the object once it has resolved", () => {
+    expect(wantedEvent({ ...event, objectId: "root" }, { object: "O" }, ids, items)).toBe(true)
+    expect(wantedEvent({ ...event, objectId: "elsewhere" }, { object: "O" }, ids, items)).toBe(
+      false,
+    )
+  })
+
+  it("applies the target filter with no object named", () => {
+    const command = { targets: true }
+
+    expect(
+      wantedEvent({ ...event, item: { rootId: "id", name: "Main" } }, command, undefined, items),
+    ).toBe(true)
+
+    expect(
+      wantedEvent({ ...event, item: { rootId: "id", name: "Other" } }, command, undefined, items),
+    ).toBe(false)
+  })
+
+  it("needs both filters to pass when both were asked for", () => {
+    const command = { object: "O", targets: true }
+
+    expect(
+      wantedEvent(
+        { ...event, objectId: "root", item: { rootId: "root", name: "Main" } },
+        command,
+        ids,
+        items,
+      ),
+    ).toBe(true)
+
+    expect(
+      wantedEvent(
+        { ...event, objectId: "root", item: { rootId: "root", name: "Other" } },
+        command,
+        ids,
+        items,
+      ),
+    ).toBe(false)
   })
 })

--- a/packages/viewer-client/src/cli/commands/logs.test.ts
+++ b/packages/viewer-client/src/cli/commands/logs.test.ts
@@ -1,6 +1,18 @@
 import { describe, expect, it } from "bun:test"
 import { SourceMap } from "../../sourcemap"
-import { mapRow, mapsFor, rowIn, runtimeLines, runtimeText, sourceName, tagFor } from "./logs"
+import {
+  fromObject,
+  mapRow,
+  mapsFor,
+  namesTarget,
+  objectIds,
+  rowIn,
+  runtimeLines,
+  runtimeText,
+  sourceName,
+  tagFor,
+  withUpdate,
+} from "./logs"
 
 // Generated line 1 -> source line 1, generated line 2 -> source line 3.
 const map = SourceMap.parse(
@@ -136,5 +148,69 @@ describe("tagFor", () => {
 
   it("still calls an error an error, whichever channel carried it", () => {
     expect(tagFor("error", { ...event, channel: "owner_say" })).toContain("error")
+  })
+})
+
+describe("objectIds", () => {
+  const object = {
+    objectId: "root",
+    objectName: "Object",
+    inventory: [],
+    linkedObjects: [{ linkId: "child", linkNumber: 2, linkName: "Panel", inventory: [] }],
+  }
+
+  it("covers the root and every linked prim", () => {
+    expect(objectIds(object)).toEqual(new Set(["root", "child"]))
+  })
+
+  it("grows with a prim linked after the listing", () => {
+    const ids = withUpdate(objectIds(object), {
+      objectId: "root",
+      changes: {
+        linkedObjects: {
+          added: [{ linkId: "later", linkNumber: 3, linkName: "New", inventory: [] }],
+        },
+      },
+    })
+
+    expect(ids).toEqual(new Set(["root", "child", "later"]))
+  })
+})
+
+describe("fromObject", () => {
+  const ids = new Set(["root", "child"])
+
+  it("matches the root a newer viewer reports", () => {
+    expect(fromObject({ ...event, objectId: "root", primId: "child" }, ids)).toBe(true)
+  })
+
+  it("matches the speaking prim an older viewer reports alone", () => {
+    expect(fromObject({ ...event, objectId: "child" }, ids)).toBe(true)
+  })
+
+  it("matches on the item reference when the ids do not", () => {
+    expect(
+      fromObject({ ...event, objectId: "other", item: { rootId: "root", name: "Main" } }, ids),
+    ).toBe(true)
+  })
+
+  it("rejects another object's output", () => {
+    expect(fromObject({ ...event, objectId: "elsewhere" }, ids)).toBe(false)
+  })
+})
+
+describe("namesTarget", () => {
+  const items = new Set(["main"])
+
+  it("keeps output from an item a target deploys to, whatever its case", () => {
+    expect(namesTarget({ ...event, item: { rootId: "id", name: "Main" } }, items)).toBe(true)
+  })
+
+  it("drops output from a script the config never mentions", () => {
+    expect(namesTarget({ ...event, item: { rootId: "id", name: "Other" } }, items)).toBe(false)
+  })
+
+  it("keeps output a viewer sent without an item, which cannot be judged", () => {
+    expect(namesTarget(event, items)).toBe(true)
   })
 })

--- a/packages/viewer-client/src/cli/commands/logs.test.ts
+++ b/packages/viewer-client/src/cli/commands/logs.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test"
 import { SourceMap } from "../../sourcemap"
-import { mapRow, rowIn, runtimeLines, runtimeText } from "./logs"
+import { mapRow, mapsFor, rowIn, runtimeLines, runtimeText, sourceName, tagFor } from "./logs"
 
 // Generated line 1 -> source line 1, generated line 2 -> source line 3.
 const map = SourceMap.parse(
@@ -20,9 +20,15 @@ describe("runtimeText", () => {
   })
 
   it("says so when an error event carries no text at all", () => {
-    // The viewer currently sends the detail as a separate debug message, so
-    // this would otherwise print as an object name and nothing else.
+    // An older viewer sends the detail as a separate debug message, so this
+    // would otherwise print as an object name and nothing else.
     expect(runtimeText({ ...event, error: "", line: 0 }, "error")).toMatch(/without text/)
+  })
+
+  it("names the column too, once the viewer reports one", () => {
+    expect(runtimeText({ ...event, message: "boom", error: "", line: 4, column: 7 }, "error")).toBe(
+      "boom (line 4, column 7)",
+    )
   })
 
   it("keeps a line number the text does not already carry", () => {
@@ -87,5 +93,48 @@ describe("runtimeLines", () => {
     )
 
     expect(mapped).toEqual([{ target: "main", source: "/project/src/main.ts", line: 3 }])
+  })
+})
+
+describe("mapsFor", () => {
+  const maps = [
+    { name: "main", item: "Main", map },
+    { name: "door", item: "Door", map },
+  ]
+
+  it("narrows to the target deploying the item the event names", () => {
+    expect(mapsFor({ ...event, item: { rootId: "id", name: "Door" } }, maps)).toEqual([maps[1]!])
+  })
+
+  it("ignores case, since the viewer reports the item's own spelling", () => {
+    expect(mapsFor({ ...event, item: { rootId: "id", name: "door" } }, maps)).toEqual([maps[1]!])
+  })
+
+  it("keeps every map when no target claims the item, or none is named", () => {
+    expect(mapsFor({ ...event, item: { rootId: "id", name: "Other" } }, maps)).toEqual(maps)
+    expect(mapsFor(event, maps)).toEqual(maps)
+  })
+})
+
+describe("sourceName", () => {
+  it("addresses the script the way the other commands do", () => {
+    expect(sourceName({ ...event, item: { rootId: "id", name: "Main" } })).toBe("Object/Main")
+  })
+
+  it("falls back to the object alone, then to its id", () => {
+    expect(sourceName(event)).toBe("Object")
+    expect(sourceName({ ...event, objectName: "" })).toBe("id")
+  })
+})
+
+describe("tagFor", () => {
+  it("separates owner say from debug output", () => {
+    expect(tagFor("debug", { ...event, channel: "owner_say" })).toContain("say")
+    expect(tagFor("debug", { ...event, channel: "debug" })).toContain("debug")
+    expect(tagFor("debug", event)).toContain("debug")
+  })
+
+  it("still calls an error an error, whichever channel carried it", () => {
+    expect(tagFor("error", { ...event, channel: "owner_say" })).toContain("error")
   })
 })

--- a/packages/viewer-client/src/cli/commands/logs.ts
+++ b/packages/viewer-client/src/cli/commands/logs.ts
@@ -147,6 +147,25 @@ export function namesTarget(params: RuntimeDebug, items: Set<string>): boolean {
   return items.has(script.toLowerCase())
 }
 
+/**
+ * Whether a runtime event belongs to the stream the flags asked for.
+ *
+ * `ids` is unset until the named object resolves, a hold as long as `--wait`
+ * allows, so naming one holds output back rather than letting every other
+ * object's through in the meantime.
+ */
+export function wantedEvent(
+  params: RuntimeDebug,
+  command: Pick<Extract<Command, { name: "logs" }>, "object" | "targets">,
+  ids: Set<string> | undefined,
+  items: Set<string>,
+): boolean {
+  if (command.object && !ids) return false
+  if (ids && !fromObject(params, ids)) return false
+
+  return !command.targets || namesTarget(params, items)
+}
+
 export function mapRow(row: number, maps: TargetMap[]): MappedLocation[] {
   if (row <= 0) return []
 
@@ -302,15 +321,10 @@ async function streamOnce(
 
   // The viewer forwards every published object's output to every connection,
   // so naming one object only narrows the stream if we do it here. Unset until
-  // the object resolves below, which lets output produced while the viewer is
-  // still publishing through rather than swallowing it.
+  // the object resolves below.
   let ids: Set<string> | undefined
 
-  const wanted = (params: RuntimeDebug): boolean => {
-    if (ids && !fromObject(params, ids)) return false
-
-    return !command.targets || namesTarget(params, targets.items)
-  }
+  const wanted = (params: RuntimeDebug): boolean => wantedEvent(params, command, ids, targets.items)
 
   // Registered before the round trips below, so output produced while the
   // viewer is publishing still reaches the stream.

--- a/packages/viewer-client/src/cli/commands/logs.ts
+++ b/packages/viewer-client/src/cli/commands/logs.ts
@@ -1,6 +1,7 @@
 import { isAbsolute, resolve } from "node:path"
 import pc from "picocolors"
 import {
+  eachPrim,
   ensurePublished,
   parseObjectSelector,
   PUBLISH_HINT,
@@ -9,7 +10,12 @@ import {
   waitForAnyPublish,
 } from "../../addressing.js"
 import { ViewerClient } from "../../client.js"
-import type { RuntimeDebug, RuntimeError } from "../../protocol/types.js"
+import type {
+  ObjectUpdateMessage,
+  PublishedObject,
+  RuntimeDebug,
+  RuntimeError,
+} from "../../protocol/types.js"
 import { loadSourceMapFor, type SourceMap } from "../../sourcemap.js"
 import { loadConfig } from "../../targets.js"
 import type { Command, GlobalFlags } from "../args.js"
@@ -31,21 +37,29 @@ export interface MappedLocation {
   line: number
 }
 
+export interface Targets {
+  maps: TargetMap[]
+  /** Lowercased item names the config's targets deploy to. */
+  items: Set<string>
+}
+
 /**
- * Source maps for every target in `slua.json`.
+ * What `slua.json` says about the scripts this project deploys.
  *
  * Runtime output reports positions in the generated Lua (`lua_script:5`),
  * which is not a file anyone wrote, so the same maps that bring compile errors
- * home are worth having here too.
+ * home are worth having here too. The item names are what `--targets` filters
+ * on, and a target without a source map still counts for that.
  */
-async function loadTargetMaps(): Promise<TargetMap[]> {
+async function loadTargets(): Promise<Targets> {
   const config = await loadConfig()
-
-  if (!config) return []
-
   const maps: TargetMap[] = []
+  const items = new Set<string>()
+
+  if (!config) return { maps, items }
 
   for (const [name, target] of Object.entries(config.targets)) {
+    if (target.item) items.add(target.item.toLowerCase())
     if (!target.file) continue
 
     const file = isAbsolute(target.file) ? target.file : resolve(config.root, target.file)
@@ -54,7 +68,7 @@ async function loadTargetMaps(): Promise<TargetMap[]> {
     if (map) maps.push({ name, item: target.item, map })
   }
 
-  return maps
+  return { maps, items }
 }
 
 /**
@@ -90,6 +104,47 @@ export function mapsFor(params: RuntimeDebug, maps: TargetMap[]): TargetMap[] {
   const named = maps.filter((entry) => entry.item?.toLowerCase() === script.toLowerCase())
 
   return named.length > 0 ? named : maps
+}
+
+/**
+ * Every id a runtime event could name for one published object.
+ *
+ * A viewer advertising `unifiedDiagnostics` reports `objectId` as the
+ * linkset's root and the speaking prim as `primId`; an older one puts the
+ * speaking prim in `objectId` alone, so a script in a child prim never names
+ * the root at all. Listing every prim matches both.
+ */
+export function objectIds(object: PublishedObject): Set<string> {
+  return new Set(eachPrim(object).map((prim) => prim.primId))
+}
+
+/** Adds any prims an update brought with it. */
+export function withUpdate(ids: Set<string>, update: ObjectUpdateMessage): Set<string> {
+  const links = update.changes?.linkedObjects?.added ?? update.linkedObjects ?? []
+
+  // Only ever grows: an id that stopped being ours risks keeping a line,
+  // where forgetting one risks losing output the stream was asked for.
+  return new Set([...ids, update.objectId, ...links.map((link) => link.linkId)])
+}
+
+export function fromObject(params: RuntimeDebug, ids: Set<string>): boolean {
+  return [params.item?.rootId, params.objectId, params.primId].some(
+    (id) => id !== undefined && ids.has(id),
+  )
+}
+
+/**
+ * Whether an event names an item one of the config's targets deploys to.
+ *
+ * A viewer that sends no item reference cannot be filtered this way, so its
+ * output is kept rather than quietly dropped. `logs` says so once instead.
+ */
+export function namesTarget(params: RuntimeDebug, items: Set<string>): boolean {
+  const script = params.item?.name
+
+  if (!script) return true
+
+  return items.has(script.toLowerCase())
 }
 
 export function mapRow(row: number, maps: TargetMap[]): MappedLocation[] {
@@ -233,15 +288,50 @@ async function streamOnce(
   global: GlobalFlags,
   command: Extract<Command, { name: "logs" }>,
   reporter: Reporter,
-  maps: TargetMap[],
+  targets: Targets,
   publish: PublishOptions,
 ): Promise<ViewerClient> {
   const client = await ViewerClient.connect({ port: global.port, timeoutMs: global.timeoutMs })
 
+  // The viewer forwards every published object's output to every connection,
+  // so naming one object only narrows the stream if we do it here. Unset until
+  // the object resolves below, which lets output produced while the viewer is
+  // still publishing through rather than swallowing it.
+  let ids: Set<string> | undefined
+
+  const wanted = (params: RuntimeDebug): boolean => {
+    if (ids && !fromObject(params, ids)) return false
+
+    return !command.targets || namesTarget(params, targets.items)
+  }
+
   // Registered before the round trips below, so output produced while the
   // viewer is publishing still reaches the stream.
-  client.on("runtime.debug", (params) => emit(reporter, "debug", params, maps))
-  client.on("runtime.error", (params) => emit(reporter, "error", params, maps))
+  client.on("runtime.debug", (params) => {
+    if (wanted(params)) emit(reporter, "debug", params, targets.maps)
+  })
+
+  client.on("runtime.error", (params) => {
+    if (wanted(params)) emit(reporter, "error", params, targets.maps)
+  })
+
+  // The linkset can grow while the stream runs, and a script in a prim linked
+  // after the listing would otherwise read as somebody else's output.
+  client.on("object.update", (params) => {
+    if (ids?.has(params.objectId)) ids = withUpdate(ids, params)
+  })
+
+  client.on("object.publish", (params) => {
+    if (ids?.has(params.object.objectId)) ids = objectIds(params.object)
+  })
+
+  if (command.targets && client.connection.handshake?.features.unifiedDiagnostics !== true) {
+    reporter.note(
+      pc.yellow(
+        "--targets needs a viewer that names the item its output came from; showing everything",
+      ),
+    )
+  }
 
   let watcher: PublishWatcher | undefined
 
@@ -250,6 +340,8 @@ async function streamOnce(
     // asking for one up front is the difference between output and silence.
     if (command.object) {
       const object = await ensurePublished(client, parseObjectSelector(command.object), publish)
+
+      ids = objectIds(object)
 
       reporter.note(pc.dim(`watching ${object.objectName} (${object.objectId})`))
     } else {
@@ -297,7 +389,11 @@ export async function logsCommand(
   reporter: Reporter,
   publish: PublishOptions = {},
 ): Promise<number> {
-  const maps = await loadTargetMaps()
+  const targets = await loadTargets()
+
+  if (command.targets && targets.items.size === 0) {
+    throw new Error("--targets needs a slua.json with targets that name an item")
+  }
 
   let attempt = 0
   let stopping = false
@@ -317,7 +413,7 @@ export async function logsCommand(
     // oxlint-disable-next-line no-unmodified-loop-condition -- set by the SIGINT handler above
     while (!stopping) {
       try {
-        current = await streamOnce(global, command, reporter, maps, publish)
+        current = await streamOnce(global, command, reporter, targets, publish)
         attempt = 0
 
         await new Promise<void>((resolveClosed) => {

--- a/packages/viewer-client/src/cli/commands/logs.ts
+++ b/packages/viewer-client/src/cli/commands/logs.ts
@@ -186,7 +186,14 @@ export function runtimeText(params: RuntimeDebug | RuntimeError, level: "debug" 
   const text = params.message || error
 
   if (text) {
-    return line > 0 && !text.includes(`:${line}:`) ? `${text} (${position(line, column)})` : text
+    if (line <= 0) return text
+
+    // The text usually names the line itself, as `lua_script:4: ...`, but it
+    // never names the column, so suppressing the whole position would lose a
+    // column the viewer went to the trouble of reporting.
+    if (!text.includes(`:${line}:`)) return `${text} (${position(line, column)})`
+
+    return column > 0 ? `${text} (column ${column})` : text
   }
 
   if (line > 0) return `error on ${position(line, column)}`

--- a/packages/viewer-client/src/cli/commands/logs.ts
+++ b/packages/viewer-client/src/cli/commands/logs.ts
@@ -20,6 +20,8 @@ const RECONNECT_MAX_MS = 30_000
 
 export interface TargetMap {
   name: string
+  /** The item the target deploys to, when the config names one. */
+  item?: string
   map: SourceMap
 }
 
@@ -49,7 +51,7 @@ async function loadTargetMaps(): Promise<TargetMap[]> {
     const file = isAbsolute(target.file) ? target.file : resolve(config.root, target.file)
     const map = await loadSourceMapFor(file)
 
-    if (map) maps.push({ name, map })
+    if (map) maps.push({ name, item: target.item, map })
   }
 
   return maps
@@ -70,6 +72,24 @@ export function rowIn(text: string): number {
   const match = RUNTIME_POSITION.exec(text.trim())
 
   return match ? Number(match[1]) : 0
+}
+
+/**
+ * The maps that could describe the script an event came from.
+ *
+ * A viewer advertising `unifiedDiagnostics` names the item its output came
+ * from, so a row that several targets' maps happen to cover need no longer be
+ * reported against all of them. An event with no item, or one naming an item
+ * no target claims, still falls back to every map.
+ */
+export function mapsFor(params: RuntimeDebug, maps: TargetMap[]): TargetMap[] {
+  const script = params.item?.name
+
+  if (!script) return maps
+
+  const named = maps.filter((entry) => entry.item?.toLowerCase() === script.toLowerCase())
+
+  return named.length > 0 ? named : maps
 }
 
 export function mapRow(row: number, maps: TargetMap[]): MappedLocation[] {
@@ -93,22 +113,31 @@ function formatLocation(location: MappedLocation, ambiguous: boolean): string {
   return ambiguous ? `${where} (${location.target})` : where
 }
 
+function position(line: number, column: number): string {
+  return column > 0 ? `line ${line}, column ${column}` : `line ${line}`
+}
+
 /**
  * The text of a runtime event.
  *
- * `runtime.error` currently arrives with `error` empty and `line` zero — the
- * viewer sends the detail as a separate `runtime.debug` message — so an error
- * would otherwise print as a bare object name and nothing else.
+ * The message is the whole raw chat line and carries the traceback with it,
+ * so it wins over the viewer's extracted `error`. On a viewer without
+ * `unifiedDiagnostics` both that and `line` arrive empty, and the detail
+ * follows as a separate `runtime.debug` message, so an error would otherwise
+ * print as a bare object name and nothing else.
  */
 export function runtimeText(params: RuntimeDebug | RuntimeError, level: "debug" | "error"): string {
-  const { error = "", line = 0 } = params as RuntimeError
+  const { error = "", line = 0, column = 0 } = params as RuntimeError
   const text = params.message || error
 
-  if (text) return line > 0 && !text.includes(`:${line}:`) ? `${text} (line ${line})` : text
-  if (line > 0) return `error on line ${line}`
+  if (text) {
+    return line > 0 && !text.includes(`:${line}:`) ? `${text} (${position(line, column)})` : text
+  }
+
+  if (line > 0) return `error on ${position(line, column)}`
 
   return level === "error"
-    ? "script error without text; the viewer sends the detail as a debug message"
+    ? "script error without text; an older viewer sends the detail as a separate debug message"
     : ""
 }
 
@@ -141,13 +170,40 @@ export function runtimeLines(
   return { lines, mapped: [...rows].flatMap((row) => mapRow(row, maps)) }
 }
 
+/**
+ * The tag a line carries.
+ *
+ * `owner_say` is the script talking to its owner rather than debug output,
+ * and the two are indistinguishable without the channel the viewer now sends.
+ */
+export function tagFor(level: "debug" | "error", params: RuntimeDebug): string {
+  if (level === "error") return pc.red("error")
+
+  return params.channel === "owner_say" ? pc.dim("say") : pc.dim("debug")
+}
+
+/**
+ * Who produced a line.
+ *
+ * The same `object/item` addressing the other commands take, so a name read
+ * out of the stream can be pasted straight into a `pull` or a `push`. The
+ * item half needs a viewer advertising `unifiedDiagnostics`.
+ */
+export function sourceName(params: RuntimeDebug): string {
+  const object = params.objectName || params.objectId
+  const script = params.item?.name
+
+  return script ? `${object}/${script}` : object
+}
+
 function emit(
   reporter: Reporter,
   level: "debug" | "error",
   params: RuntimeDebug | RuntimeError,
   maps: TargetMap[],
 ) {
-  const { lines, mapped } = runtimeLines(params, level, maps)
+  const scoped = mapsFor(params, maps)
+  const { lines, mapped } = runtimeLines(params, level, scoped)
 
   if (reporter.json) {
     // A stream gets one JSON object per line, not one document.
@@ -156,11 +212,10 @@ function emit(
     return
   }
 
-  const name = params.objectName || params.objectId
-  const tag = level === "error" ? pc.red("error") : pc.dim("debug")
-  const ambiguous = maps.length > 1
+  const tag = tagFor(level, params)
+  const ambiguous = scoped.length > 1
 
-  reporter.line(`${tag} ${pc.bold(name)}  ${lines[0] ?? ""}`)
+  reporter.line(`${tag} ${pc.bold(sourceName(params))}  ${lines[0] ?? ""}`)
 
   // The traceback belongs to the line above it, so it is indented under it
   // rather than tagged again as output of its own.

--- a/packages/viewer-client/src/cli/commands/push.test.ts
+++ b/packages/viewer-client/src/cli/commands/push.test.ts
@@ -228,3 +228,49 @@ describe("pushCommand with --wait", () => {
     expect(notes).toEqual([])
   })
 })
+
+describe("pushCommand on a failed compile", () => {
+  it("reports the diagnostics the viewer parsed for us", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "slua-push-"))
+
+    await mkdir(join(dir, "dist"))
+    await writeFile(join(dir, "dist", "second.slua"), "local x = 1\nfoo()\n", "utf8")
+    await writeFile(
+      join(dir, "slua.json"),
+      JSON.stringify({
+        targets: { second: { file: "dist/second.slua", object: "name:Second", item: "Main" } },
+      }),
+      "utf8",
+    )
+
+    const client = {
+      objectList: async () => ({ objects: [published] }),
+      objectContentSave: async () => ({
+        success: true,
+        compiled: false,
+        diagnostics: [{ row: 2, column: 0, level: "ERROR", message: "Unknown global 'foo'" }],
+      }),
+    } as unknown as ViewerClient
+
+    const reporter = collectingReporter()
+    const cwd = process.cwd()
+
+    process.chdir(dir)
+
+    let code: number
+
+    try {
+      code = await pushCommand(client, { name: "push", target: "second" }, reporter)
+    } finally {
+      process.chdir(cwd)
+
+      await rm(dir, { recursive: true, force: true })
+    }
+
+    expect(code).toBe(1)
+    expect(reporter.errors).toEqual([expect.stringContaining("second.slua:2: Unknown global")])
+    expect((reporter.payload as { errors: { row: number }[] }).errors).toEqual([
+      expect.objectContaining({ row: 2, message: "Unknown global 'foo'" }),
+    ])
+  })
+})

--- a/packages/viewer-client/src/cli/commands/push.ts
+++ b/packages/viewer-client/src/cli/commands/push.ts
@@ -9,9 +9,9 @@ import {
   withStaleRetry,
 } from "../../addressing.js"
 import type { ViewerClient } from "../../client.js"
-import { type CompileLanguage, parseCompileErrors } from "../../compile-errors.js"
+import { type CompileLanguage, diagnosticsFrom } from "../../compile-errors.js"
 import { ConnectionClosedError } from "../../protocol/errors.js"
-import type { ObjectInventoryItem, ScriptVM } from "../../protocol/types.js"
+import type { Diagnostic, ObjectInventoryItem, ScriptVM } from "../../protocol/types.js"
 import { loadSourceMapFor, type SourceMap } from "../../sourcemap.js"
 import {
   type Config,
@@ -239,7 +239,7 @@ async function pushTarget(
   // A save can succeed while the compile fails; the source is stored either way.
   if (response.compiled === false) {
     const language: CompileLanguage = vm === "luau" ? "luau" : "lsl"
-    const errors = parseCompileErrors(response.errors, language)
+    const errors = diagnosticsFrom(response, language)
     const sourceMap = await loadSourceMapFor(target.file)
     const payload = await reportCompileErrors(errors, target.file, sourceMap, reporter, base, label)
 
@@ -303,7 +303,7 @@ async function saveBackToContents(
 }
 
 async function reportCompileErrors(
-  errors: ReturnType<typeof parseCompileErrors>,
+  errors: readonly Diagnostic[],
   file: string,
   sourceMap: SourceMap | undefined,
   reporter: Reporter,

--- a/packages/viewer-client/src/compile-errors.test.ts
+++ b/packages/viewer-client/src/compile-errors.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test"
-import { parseCompileError, parseCompileErrors } from "./compile-errors"
+import { diagnosticsFrom, parseCompileError, parseCompileErrors } from "./compile-errors"
 
 describe("parseCompileError", () => {
   it("parses a Luau error, which is already 1-based and has no column", () => {
@@ -56,5 +56,30 @@ describe("parseCompileErrors", () => {
     const parsed = parseCompileErrors(["a.luau:1: first", "a.luau:2: second"], "luau")
 
     expect(parsed.map((error) => error.row)).toEqual([1, 2])
+  })
+})
+
+describe("diagnosticsFrom", () => {
+  it("takes the viewer's own parse when it sent one", () => {
+    const diagnostic = { row: 3, column: 0, level: "ERROR", message: "Unknown global" }
+
+    expect(
+      diagnosticsFrom({ diagnostics: [diagnostic], errors: ["a.luau:9: stale"] }, "luau"),
+    ).toEqual([diagnostic])
+  })
+
+  it("parses the raw lines from a viewer without unifiedDiagnostics", () => {
+    expect(diagnosticsFrom({ errors: ["a.luau:2: second"] }, "luau")).toEqual([
+      { row: 2, column: 0, level: "ERROR", message: "second" },
+    ])
+  })
+
+  it("returns an empty list when the response carries neither", () => {
+    expect(diagnosticsFrom({}, "luau")).toEqual([])
+    expect(diagnosticsFrom(undefined, "luau")).toEqual([])
+  })
+
+  it("keeps an empty diagnostics array rather than falling back to errors", () => {
+    expect(diagnosticsFrom({ diagnostics: [], errors: ["a.luau:1: first"] }, "luau")).toEqual([])
   })
 })

--- a/packages/viewer-client/src/compile-errors.ts
+++ b/packages/viewer-client/src/compile-errors.ts
@@ -1,13 +1,14 @@
-import type { CompilationError } from "./protocol/types.js"
+import type { Diagnostic, ObjectContentSaveResponse } from "./protocol/types.js"
 
 /**
- * `object.content.save` hands back raw compiler output as a `string[]`.
- *
- * The viewer only parses those strings into `{row, column, ...}` on the
+ * Older viewers hand `object.content.save` failures back as raw compiler
+ * output, a `string[]`, and parse them into `{row, column, ...}` only on the
  * `script.compiled` notification path, which is routed exclusively to
- * `script.subscribe` subscribers — so on the save path it is our job. These
- * mirror the regexes in `llscripteditorws.cpp` (`sendCompileResults`), which
- * are full matches, hence the anchors.
+ * `script.subscribe` subscribers. A viewer advertising `unifiedDiagnostics`
+ * parses the save path too and sends `diagnostics` instead, so this is the
+ * fallback for the ones that do not. These mirror the regexes in
+ * `llscripteditorws.cpp` (`sendCompileResults`), which are full matches,
+ * hence the anchors.
  */
 const LUAU_ERROR = /^[^:]*:(\d+): (.+)$/
 const LSL_ERROR = /^\((\d+), (\d+)\) : ([^:]+) : (.+)$/
@@ -15,7 +16,7 @@ const LSL_ERROR = /^\((\d+), (\d+)\) : ([^:]+) : (.+)$/
 export type CompileLanguage = "luau" | "lsl"
 
 /** Parses one raw compiler line, falling back to row 0 when it doesn't match. */
-export function parseCompileError(raw: string, language: CompileLanguage): CompilationError {
+export function parseCompileError(raw: string, language: CompileLanguage): Diagnostic {
   if (language === "luau") {
     const match = LUAU_ERROR.exec(raw)
 
@@ -47,6 +48,19 @@ export function parseCompileError(raw: string, language: CompileLanguage): Compi
 export function parseCompileErrors(
   errors: readonly string[] | undefined,
   language: CompileLanguage,
-): CompilationError[] {
+): Diagnostic[] {
   return (errors ?? []).map((raw) => parseCompileError(raw, language))
+}
+
+/**
+ * The diagnostics in a save response, whichever shape the viewer sent.
+ *
+ * Prefers the viewer's own parse, since it reads the compiler output the
+ * compiler produced rather than guessing at its format from here.
+ */
+export function diagnosticsFrom(
+  response: Pick<ObjectContentSaveResponse, "diagnostics" | "errors"> | undefined,
+  language: CompileLanguage,
+): Diagnostic[] {
+  return response?.diagnostics ?? parseCompileErrors(response?.errors, language)
 }

--- a/packages/viewer-client/src/index.ts
+++ b/packages/viewer-client/src/index.ts
@@ -26,7 +26,12 @@ export {
   withStaleRetry,
 } from "./addressing.js"
 export { ViewerClient } from "./client.js"
-export { type CompileLanguage, parseCompileError, parseCompileErrors } from "./compile-errors.js"
+export {
+  type CompileLanguage,
+  diagnosticsFrom,
+  parseCompileError,
+  parseCompileErrors,
+} from "./compile-errors.js"
 export {
   ConnectionClosedError,
   HandshakeError,

--- a/packages/viewer-client/src/protocol/types.ts
+++ b/packages/viewer-client/src/protocol/types.ts
@@ -20,6 +20,11 @@ export interface SessionHandshake {
   challenge?: string
   languages: string[]
   syntaxId: string
+  /**
+   * Known flags: `liveSync`, `compilation`, `syntaxCache`, `commands` and
+   * `unifiedDiagnostics`. The last one marks the viewer build that renamed
+   * `errors` to `diagnostics` and moved runtime events onto item references.
+   */
   features: Record<string, boolean>
 }
 
@@ -215,7 +220,12 @@ export interface ObjectContentSaveResponse {
   primId?: string
   itemId?: string
   compiled?: boolean
-  /** Raw compiler output lines. Parse with `parseCompileErrors`. */
+  /**
+   * Compiler diagnostics, on a viewer advertising `unifiedDiagnostics`.
+   * Read this and `errors` together with `diagnosticsFrom`.
+   */
+  diagnostics?: Diagnostic[]
+  /** Raw compiler output lines, from a viewer without `unifiedDiagnostics`. */
   errors?: string[]
   message?: string
 }
@@ -318,36 +328,72 @@ export interface ScriptListResponse {
 
 // Compilation and runtime
 
-export interface CompilationError {
-  /** 1-based. */
+export interface Diagnostic {
+  /** 1-based, or 0 when the viewer could not place the message. */
   row: number
   /** 1-based for LSL, always 0 for Luau (the compiler gives no column). */
   column: number
   level: string
   message: string
+  /**
+   * Set when the message came from the LSL compiler. Absent is not proof of
+   * the opposite: the viewer's save path leaves it off unparsed LSL lines.
+   */
   format?: "lsl"
 }
 
+/** @deprecated Renamed to `Diagnostic`, matching the viewer's spelling. */
+export type CompilationError = Diagnostic
+
+/** Where a runtime event or diagnostic came from. */
+export interface ItemRef {
+  /** The root prim of the linkset, which is what `object.*` calls address. */
+  rootId: string
+  primId?: string
+  itemId?: string
+  name?: string
+  language?: "lsl" | "luau"
+}
+
 export interface CompilationResult {
+  /** @deprecated Kept by the viewer while it migrates to item references. */
   scriptId: string
   success: boolean
   running: boolean
-  errors?: CompilationError[]
+  /** On a viewer advertising `unifiedDiagnostics`. */
+  diagnostics?: Diagnostic[]
+  /** From a viewer without `unifiedDiagnostics`. */
+  errors?: Diagnostic[]
 }
 
 export interface RuntimeDebug {
-  /** Empty string when the message came from a published object rather than a subscription. */
-  scriptId: string
+  /**
+   * @deprecated Only sent by a viewer without `unifiedDiagnostics`, and empty
+   * there when the message came from a published object rather than a
+   * subscription. Use `item` instead.
+   */
+  scriptId?: string
+  /** The root prim of the linkset. */
   objectId: string
+  primId?: string
+  itemId?: string
   objectName: string
   message: string
+  /** `owner_say` is the script talking to its owner, not debug output. */
+  channel?: "debug" | "owner_say"
+  item?: ItemRef
 }
 
 export interface RuntimeError extends RuntimeDebug {
-  /** Currently always "" — the viewer does not yet composite the error text. */
+  /**
+   * The error on its own, without the surrounding chat text. Empty when the
+   * viewer could not parse the simulator's format, and always empty on a
+   * viewer without `unifiedDiagnostics`.
+   */
   error: string
-  /** Currently always 0, for the same reason. */
+  /** The line the error names, or 0 when it names none. */
   line: number
+  column?: number
   stack?: string[]
 }
 


### PR DESCRIPTION
This PR brings the client inline with latest changes on `project/lua_editor`, providing support for newer builds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added unified compilation diagnostics with viewer-provided error details when available.
  - `push` now reports compilation diagnostics accurately and returns a failure status when compilation fails.
  - Added `logs --targets` filtering for item-specific runtime output.
  - Runtime logs now show object/item labels, clearer message types, source locations, and item-aware target mapping.

- **Documentation**
  - Updated guidance for diagnostics, target filtering, enhanced logs, and viewer compatibility.

- **Tests**
  - Expanded coverage for diagnostics, compilation failures, log formatting, filtering, and target mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->