### PR TITLE
feat(viewer-client): persistent sessions

### DIFF
--- a/.changeset/lucky-moons-drain.md
+++ b/.changeset/lucky-moons-drain.md
@@ -1,0 +1,5 @@
+---
+"@gwigz/slua-viewer-client": minor
+---
+
+`push` now prints the output its own save produced, with `--tail` to keep listening and `--no-tail` to opt out

--- a/.changeset/quiet-otters-connect.md
+++ b/.changeset/quiet-otters-connect.md
@@ -1,0 +1,5 @@
+---
+"@gwigz/slua-viewer-client": minor
+---
+
+`connect` holds one viewer session that watches, pushes and streams output in one terminal, reachable by agents over a control socket, an mcp server and `.slua/logs.jsonl`

--- a/.changeset/soft-lamps-scaffold.md
+++ b/.changeset/soft-lamps-scaffold.md
@@ -1,0 +1,5 @@
+---
+"@gwigz/slua-create": minor
+---
+
+scaffolded `dev` now runs `slua-viewer connect`, and the watch build moves to `build:watch`

--- a/apps/web/content/docs/create/templates.mdx
+++ b/apps/web/content/docs/create/templates.mdx
@@ -7,7 +7,7 @@ description: Available project templates and optional extras
 
 The `single` template produces the simplest possible project layout, one
 `new-script.ts` file at the project root that compiles to a single flat
-`out/new-script.slua` via TSTL. Imports (including vendored modules) are
+`dist/new-script.slua` via TSTL. Imports (including vendored modules) are
 bundled into that one output file, then tree-shaken by
 `@gwigz/tstl-bundle-flatten` so unused code is removed from the output.
 

--- a/apps/web/content/docs/viewer-client/cli.mdx
+++ b/apps/web/content/docs/viewer-client/cli.mdx
@@ -54,6 +54,10 @@ requested that way, since the viewer has no way to look them up.
 | `reset <object>/<item>`               | Reset a script                               |
 | `set-running on\|off <object>/<item>` | Start or stop a script                       |
 | `logs`                                | Stream runtime output from published objects |
+| `connect`                             | Hold a session: watch, push and tail in one  |
+| `status`                              | What the running session is doing            |
+| `wait`                                | Block until the next push settles            |
+| `mcp`                                 | Serve the session to an agent over MCP       |
 | `syntax [defs.lsl\|defs.lua]`         | Dump language definitions                    |
 
 ### objects
@@ -87,6 +91,26 @@ A save can succeed while the compile fails, the source is stored either way.
 Either failure exits non-zero, and with `--all` a failing target does not
 strand the ones behind it.
 
+A save also restarts the script, so whatever its `state_entry` says is on the
+wire within milliseconds. `push` keeps listening for a moment (1.5s) and prints
+what arrives under the compile result, scoped to the object and item it just
+pushed, rather than dropping it on a closed socket:
+
+```
+compiled Main.luau in My Rezzer
+say My Rezzer/Main  ready
+```
+
+`--tail 10s` widens the window, `--tail` on its own keeps listening until you
+interrupt it, and `--no-tail` skips it for scripted use. The result payload
+carries a `cursor`, the point everything the push caused comes after.
+
+<Callout title="The window only covers the restart">
+  A bounded `--tail` catches the output the save itself caused and then exits. Whatever the script
+  says afterwards, when someone touches it or a timer fires, needs a connection that is still open.
+  That is [`connect`](#connect), or `logs --follow`.
+</Callout>
+
 ### pull
 
 Writes the item's content to `out`, or to stdout when no path is given. Content
@@ -102,6 +126,12 @@ Streams `runtime.debug` and `runtime.error` output, stack frames included.
 Runtime output is only forwarded for published objects, so pass `--object` with
 a UUID to have one published on demand, or `--wait` to hold the connection open
 while you publish one from the viewer.
+
+Output arrives live or not at all. The viewer buffers nothing, and the protocol
+has no way to ask for what it already sent, so a line spoken while nothing was
+connected is gone. Since most of what a script says follows a touch, a listen, a
+timer or an HTTP response rather than anything you typed, that argues for
+keeping something connected. See [connect](#connect).
 
 The viewer forwards every published object's output to every connection, so
 `--object` narrows the stream to the one you named, matching against each prim
@@ -123,7 +153,60 @@ runtime events.
 slua-viewer logs --object 4f2b0c1e-... --follow
 ```
 
-With `--follow` it reconnects with backoff when the viewer restarts.
+`--follow` holds the connection and reconnects with backoff when the viewer
+restarts, so a restart costs you the gap rather than everything after it. Run it
+this way unless you are scripting against it.
+
+`--since` takes a cursor, the number each record carries in `--json` output, or
+a duration like `5m`. It reads from a running session when there is one, and
+from `.slua/logs.jsonl` when there is not, which is exactly when someone wants
+to know what the script said.
+
+### connect
+
+`push` and `logs` connect, do one thing and let go. `connect` stays, which is
+what the viewer expects. It publishes objects to whichever editor client is
+attached at the time, and it sends runtime output only to connections that are
+open at the moment a script speaks. A session still holding the connection hears
+the `llOwnerSay` from a touch you make ten minutes later, and lets you press
+**"Explore in IDE"** on a new object whenever you like. A command that exited
+hears nothing and publishes nothing.
+
+A session is one viewer connection, watching the built outputs your `slua.json`
+names, pushing when they change, and printing what your scripts say for as long
+as you keep it open.
+
+```bash
+slua-viewer connect --exec "bun run build:watch"
+```
+
+`--exec` runs your build inside the session and prefixes its output, so the
+whole loop is one terminal. The scaffolds wire this up as `bun run dev`.
+
+Watching is a behaviour of the session rather than the point of it.
+`--no-watch` still holds the connection, still streams output and still serves
+the control socket, which is what an agent driving pushes explicitly wants.
+
+Every push restarts the script and costs an asset upload through the simulator,
+so the watcher is built to decide when a burst of edits has _finished_ rather
+than to react quickly: a 3s trailing debounce (`--debounce`, `--edge leading`),
+changes during a push collapsed into one follow-up rather than a queue, a
+minimum interval per item, and a rebuild that produced identical bytes ignored
+outright.
+
+A failed compile says what it left behind: the save succeeded, so the item now
+holds source that never compiled, while the previously compiled version keeps
+running.
+
+While a session is running, the other commands go through it rather than
+opening their own connection. `--direct` opts out.
+
+### status, wait and mcp
+
+`status` reports what the session is doing, `wait` blocks until a push newer
+than a given cursor settles and then reports its results with the output that
+followed, and `mcp` serves both to an agent over stdio MCP. See
+[Driving it from an agent](#driving-it-from-an-agent).
 
 ### syntax
 
@@ -151,25 +234,94 @@ cannot be addressed. Addressing it by UUID publishes it on demand; a name or a
 description key needs the object published from the viewer first, see
 [Publishing an object](#publishing-an-object).
 
+## A session's state
+
+`connect` keeps `.slua/` beside your `slua.json`: `session.json` (pid, socket
+path, viewer port, CLI version, removed on a clean exit) and `logs.jsonl`,
+every runtime record and push result as one JSON object per line. The log
+survives the session crashing and rotates at 5MB, keeping one previous file.
+
+<Callout title="Ignore it">
+  Add `.slua/` to your `.gitignore`. Projects scaffolded with `@gwigz/slua-create` already do.
+</Callout>
+
+## Driving it from an agent
+
+Three tiers, in order of how little integration they need.
+
+**Read the file.** `tail -n 100 .slua/logs.jsonl` needs nothing from us at all,
+and still answers after the session has gone.
+
+**Run the CLI.** `status`, `wait` and `logs --since` are thin wrappers over the
+session, and everything speaks `--json`:
+
+```bash
+slua-viewer status --json
+slua-viewer wait --since 412 --for 20s
+slua-viewer logs --since 5m
+```
+
+`wait` takes the cursor you last saw, not "the current push". Asking to wait
+for the in-flight push is only correct if one is already in flight, and usually
+none is, so that form would hand back the _previous_ run's results as though
+they were current.
+
+**Speak MCP.** `slua-viewer mcp` is a stdio MCP server over the session's
+control socket, exposing `slua_status`, `slua_push`, `slua_wait` and
+`slua_logs`. `slua_push` pushes and waits in one call, returning the compile
+result per target and the output the restarted script produced.
+
+```jsonc
+{
+  "mcpServers": {
+    "slua": { "command": "slua-viewer", "args": ["mcp"], "cwd": "/path/to/project" },
+  },
+}
+```
+
+### The control socket
+
+The session listens on a unix socket, a named pipe on Windows, at mode 0600 in
+your temp directory, keyed by a hash of the project root. The path is recorded
+in `.slua/session.json`.
+
+It speaks the viewer's own JSON-RPC, so a `ViewerClient` connects to a session
+exactly as it connects to the viewer and only the `control.*` namespace is new.
+Viewer calls are forwarded upstream, viewer notifications broadcast back down.
+
+<Callout type="warn" title="Local processes">
+  Any local process that can reach that socket can push scripts to your viewer. That is already true
+  of port 9020 itself, so it is not a new exposure, but it is worth knowing.
+</Callout>
+
 ## Options
 
-| Flag                  | Applies to     | Meaning                                              |
-| --------------------- | -------------- | ---------------------------------------------------- |
-| `--object <id\|name>` | most           | Target object, same grammar as the object segment    |
-| `--item <id\|name>`   | most           | Target inventory item                                |
-| `--link <id\|name>`   | most           | Child prim within the linkset                        |
-| `--vm <vm>`           | `push`         | Compile target: `luau`, `mono`, `lsl2`               |
-| `--target <name>`     | `push`         | Deploy a named target from `slua.json`               |
-| `--all`               | `push`         | Deploy every target in `slua.json`                   |
-| `--save-back`         | `push`         | Derez back into the source prim after a good compile |
-| `--file <path>`       | `push`, `link` | File to push, or to record when linking              |
-| `--key <key>`         | `link`         | Description key to pair on, default `slua:<name>`    |
-| `-f`, `--follow`      | `logs`         | Keep streaming, reconnecting if the viewer restarts  |
-| `--targets`           | `logs`         | Only output from items your `slua.json` targets      |
-| `--wait`              | most           | Hold the viewer connection open until it publishes   |
-| `--port <port>`       | all            | Viewer websocket port, default `9020`                |
-| `--timeout <ms>`      | all            | Request timeout                                      |
-| `--json`              | all            | Machine-readable output on stdout                    |
+| Flag                         | Applies to     | Meaning                                               |
+| ---------------------------- | -------------- | ----------------------------------------------------- |
+| `--object <id\|name>`        | most           | Target object, same grammar as the object segment     |
+| `--item <id\|name>`          | most           | Target inventory item                                 |
+| `--link <id\|name>`          | most           | Child prim within the linkset                         |
+| `--vm <vm>`                  | `push`         | Compile target: `luau`, `mono`, `lsl2`                |
+| `--target <name>`            | `push`         | Deploy a named target from `slua.json`                |
+| `--all`                      | `push`         | Deploy every target in `slua.json`                    |
+| `--save-back`                | `push`         | Derez back into the source prim after a good compile  |
+| `--file <path>`              | `push`, `link` | File to push, or to record when linking               |
+| `--key <key>`                | `link`         | Description key to pair on, default `slua:<name>`     |
+| `-f`, `--follow`             | `logs`         | Keep streaming, reconnecting if the viewer restarts   |
+| `--targets`                  | `logs`         | Only output from items your `slua.json` targets       |
+| `--tail [duration]`          | `push`         | Keep listening after the push, `5s`, or until ctrl-c  |
+| `--no-tail`                  | `push`         | Push without waiting for output at all                |
+| `--watch`/`--no-watch`       | `connect`      | Push when a target's output changes, on by default    |
+| `--debounce <ms>`            | `connect`      | How long a target must be quiet first, default `3000` |
+| `--edge <edge>`              | `connect`      | `trailing` (default) or `leading`                     |
+| `--exec <command>`           | `connect`      | Run a build alongside the session                     |
+| `--since <cursor\|duration>` | `logs`, `wait` | Output after a cursor, or from the last `5m`          |
+| `--for <duration>`           | `wait`         | How long to block, default `30s`                      |
+| `--direct`                   | all            | Talk to the viewer even with a session running        |
+| `--wait`                     | most           | Hold the viewer connection open until it publishes    |
+| `--port <port>`              | all            | Viewer websocket port, default `9020`                 |
+| `--timeout <ms>`             | all            | Request timeout                                       |
+| `--json`                     | all            | Machine-readable output on stdout                     |
 
 ## Compile errors
 
@@ -202,8 +354,11 @@ slua-viewer push dist/main.slua --json | jq .compiled
 ```
 
 A failure still emits a document (`{"ok": false, "error": "..."}`), so an empty
-stdout always means something went badly wrong. `logs --json` is the exception:
-it emits one JSON object per line, since it is a stream.
+stdout always means something went badly wrong. A bounded `push --tail` keeps
+that contract by attaching what it drained to the document as `logs`. Streams
+are the exception, and emit one JSON object per line: `logs --json`, and a
+`push --json --tail` given no duration to stop at, which prints its document
+first and then streams.
 
 Keys are camelCase (`objectId`, `primId`, `itemId`, `savedBack`), matching the
 library rather than the viewer's wire format. See

--- a/apps/web/content/docs/viewer-client/cli.mdx
+++ b/apps/web/content/docs/viewer-client/cli.mdx
@@ -4,43 +4,33 @@ description: Commands, addressing, flags, and JSON output for slua-viewer
 icon: Terminal
 ---
 
-The package installs a `slua-viewer` bin. Examples below use that name, which
-resolves inside a package script or after a devDependency install. Prefix them
-with `bunx @gwigz/slua-viewer-client` (or `npx`, `pnpm dlx`) to run them
-straight from a shell.
+The package installs a `slua-viewer` bin. Examples use that name, which resolves
+inside a package script or after a devDependency install. From a bare shell,
+prefix them with `bunx @gwigz/slua-viewer-client` (or `npx`, `pnpm dlx`).
 
 ## Publishing an object
 
-Nothing can be read or written until the viewer publishes the object to the
-editor, and selecting it does not do that. Publishing is a button: open the
-object's Build window, go to **Content** and press **"Explore in IDE"**.
+Nothing can be read or written until the viewer publishes the object, and
+selecting it does not do that. Open the object's Build window, go to **Content**
+and press **"Explore in IDE"**.
 
-The catch is that the viewer only publishes when an editor client is already
-connected. Press it with nothing connected and it launches your external editor
-instead, which is why the button can look like it does nothing for this CLI.
-So connect first:
+The button only works when an editor client is already connected. Press it with
+nothing connected and it launches your external editor instead, which is why it
+can look like it does nothing here. So connect first:
 
 ```bash
 slua-viewer push dist/main.slua --wait
 ```
 
-`--wait` holds the connection open and says what it is waiting for, then
-carries on the moment the object arrives. It applies to every command that
-resolves or lists a published object, including `objects --wait` to see what
-you just published, and `logs --wait` to catch output from the start. `syntax`,
-`--help` and `--version` never touch a published object, so it does nothing
-there.
-
-Addressing an object by UUID skips all of this: the viewer publishes it on
-demand, no button and no waiting. Names and description keys cannot be
-requested that way, since the viewer has no way to look them up.
+`--wait` holds the connection open until the object arrives, saying what it is
+waiting for. Every command that resolves or lists a published object takes it.
+Addressing an object by UUID skips all of this, since the viewer publishes those
+on demand. Names and description keys it cannot look up.
 
 <Callout title="Stale inventory">
-  The published inventory goes briefly stale right after a save. Sometimes the item, or the whole
-  object, drops out of the listing; sometimes the listing is fine and the next save comes back as
-  `Item not found in prim inventory` even though the item is there and its id has not changed.
-  Commands re-read the object and retry a few times before giving up, so a `push --all` that touches
-  several scripts in a row is not derailed by it.
+  The published inventory goes briefly stale right after a save. The item, or the whole object, can
+  drop out of the listing, or a save comes back as `Item not found in prim inventory` with the item
+  still there under the same id. Commands re-read and retry a few times before giving up.
 </Callout>
 
 ## Commands
@@ -60,58 +50,47 @@ requested that way, since the viewer has no way to look them up.
 | `mcp`                                 | Serve the session to an agent over MCP       |
 | `syntax [defs.lsl\|defs.lua]`         | Dump language definitions                    |
 
-### objects
+### `objects`
 
-Lists every published object, its child prims, and their inventory, with each
-script marked `running` or `stopped`, alongside the object's description, which
-is where `link` keys live. An empty list means nothing has been published yet.
+Every published object, its child prims and their inventory, each script marked
+`running` or `stopped`, with the object's description, where `link` keys live.
 
 ```bash
 slua-viewer objects
 ```
 
-### push
+### `push`
 
-Uploads a file and compiles it in place. The script's current running state is
-preserved, so pushing to a stopped script does not start it.
+Uploads a file and compiles it in place, preserving the script's running state.
 
 ```bash
 slua-viewer push dist/main.slua 4f2b0c1e-.../Main
 ```
 
-The destination can also come from `slua.json` or a source header, in which
-case the file alone is enough, and `--target` or `--all` cover multi-script
-projects. See [Targets](/docs/viewer-client/targets).
+The destination can also come from `slua.json` or a source header, in which case
+the file alone is enough, with `--target` and `--all` for multi-script projects.
+See [Targets](/docs/viewer-client/targets). The VM comes from `--vm`, then the
+extension (`.slua`, `.luau` and `.lua` are `luau`, `.lsl` is `mono`), then
+whatever the item already is.
 
-The compile target is picked from `--vm`, then the file extension (`.slua`,
-`.luau` and `.lua` compile as `luau`, `.lsl` as `mono`), then whatever the item
-already is.
+A save can succeed while the compile fails, and the source is stored either way.
+Either failure exits non-zero, and with `--all` the targets behind it still run.
 
-A save can succeed while the compile fails, the source is stored either way.
-Either failure exits non-zero, and with `--all` a failing target does not
-strand the ones behind it.
-
-A save also restarts the script, so whatever its `state_entry` says is on the
-wire within milliseconds. `push` keeps listening for a moment (1.5s) and prints
-what arrives under the compile result, scoped to the object and item it just
-pushed, rather than dropping it on a closed socket:
+A save also restarts the script, so `push` listens for 1.5s afterwards and
+prints what that object and item said under the compile result:
 
 ```
 compiled Main.luau in My Rezzer
 say My Rezzer/Main  ready
 ```
 
-`--tail 10s` widens the window, `--tail` on its own keeps listening until you
-interrupt it, and `--no-tail` skips it for scripted use. The result payload
-carries a `cursor`, the point everything the push caused comes after.
+`--tail 10s` widens that window, bare `--tail` listens until you interrupt it,
+and `--no-tail` skips it. The result carries a `cursor`, the point everything
+the push caused comes after. Anything the script says later, from a touch or a
+timer, needs a connection that is still open, so [`connect`](#connect) or
+`logs --follow`.
 
-<Callout title="The window only covers the restart">
-  A bounded `--tail` catches the output the save itself caused and then exits. Whatever the script
-  says afterwards, when someone touches it or a timer fires, needs a connection that is still open.
-  That is [`connect`](#connect), or `logs --follow`.
-</Callout>
-
-### pull
+### `pull`
 
 Writes the item's content to `out`, or to stdout when no path is given. Content
 the viewer base64-encodes is decoded for you.
@@ -120,61 +99,44 @@ the viewer base64-encodes is decoded for you.
 slua-viewer pull "My Rezzer/Main" src/main.recovered.luau
 ```
 
-### logs
+### `logs`
 
 Streams `runtime.debug` and `runtime.error` output, stack frames included.
-Runtime output is only forwarded for published objects, so pass `--object` with
-a UUID to have one published on demand, or `--wait` to hold the connection open
-while you publish one from the viewer.
-
-Output arrives live or not at all. The viewer buffers nothing, and the protocol
-has no way to ask for what it already sent, so a line spoken while nothing was
-connected is gone. Since most of what a script says follows a touch, a listen, a
-timer or an HTTP response rather than anything you typed, that argues for
-keeping something connected. See [connect](#connect).
-
-The viewer forwards every published object's output to every connection, so
-`--object` narrows the stream to the one you named, matching against each prim
-in its linkset. `--targets` narrows it further, to the items your `slua.json`
-targets deploy to, which needs a viewer that advertises `unifiedDiagnostics`
-and so sends an item reference with each event. Against an older viewer there
-is nothing to filter on, so `logs` warns once and shows everything.
-
-Runtime positions point at the generated Lua (`lua_script:5`), so each line is
-annotated with the TypeScript it maps to, using the source maps of the targets
-in your `slua.json`.
-
-Each line is labelled `object/item`, the same addressing `pull` and `push`
-take, and output a script sent with `llOwnerSay` is tagged `say` rather than
-`debug`. Both need a viewer new enough to send an item reference with its
-runtime events.
 
 ```bash
 slua-viewer logs --object 4f2b0c1e-... --follow
 ```
 
-`--follow` holds the connection and reconnects with backoff when the viewer
-restarts, so a restart costs you the gap rather than everything after it. Run it
-this way unless you are scripting against it.
+Output arrives live or not at all. The viewer buffers nothing and cannot replay,
+so a line spoken while nothing was connected is gone. `--follow` at least
+reconnects with backoff when the viewer restarts. Run it that way unless you are
+scripting against it.
 
-`--since` takes a cursor, the number each record carries in `--json` output, or
-a duration like `5m`. It reads from a running session when there is one, and
-from `.slua/logs.jsonl` when there is not, which is exactly when someone wants
-to know what the script said.
+Only published objects forward output, so pass `--object` with a UUID to have
+one published on demand, or `--wait` to publish it from the viewer. Every
+published object then reaches every connection, so `--object` also narrows the
+stream to one object, matching each prim in its linkset, and `--targets` narrows
+it to the items your `slua.json` deploys to.
 
-### connect
+Lines are labelled `object/item`, `llOwnerSay` output is tagged `say` rather
+than `debug`, and `--targets` has something to filter on. All three need a
+viewer advertising `unifiedDiagnostics`, which sends an item reference with each
+event. Against an older one `logs` warns once and shows everything.
 
-`push` and `logs` connect, do one thing and let go. `connect` stays, which is
-what the viewer expects. It publishes objects to whichever editor client is
-attached at the time, and it sends runtime output only to connections that are
-open at the moment a script speaks. A session still holding the connection hears
-the `llOwnerSay` from a touch you make ten minutes later, and lets you press
-**"Explore in IDE"** on a new object whenever you like. A command that exited
-hears nothing and publishes nothing.
+Runtime positions point at the generated Lua (`lua_script:5`), so each line is
+annotated with the TypeScript it maps to, using the source maps of the targets
+in your `slua.json`.
 
-A session is one viewer connection, watching the built outputs your `slua.json`
-names, pushing when they change, and printing what your scripts say for as long
-as you keep it open.
+`--since` takes a cursor, the number each record carries in `--json`, or a
+duration like `5m`. It reads from a running session, or from `.slua/logs.jsonl`
+when there is none.
+
+### `connect`
+
+`push` and `logs` do one thing and let go. `connect` stays, which is what the
+viewer expects. It hears the `llOwnerSay` from a touch you make ten minutes
+later, lets you press **"Explore in IDE"** on a new object whenever you like,
+watches the built outputs your `slua.json` names, and pushes when they change.
 
 ```bash
 slua-viewer connect --exec "bun run build:watch"
@@ -182,46 +144,39 @@ slua-viewer connect --exec "bun run build:watch"
 
 `--exec` runs your build inside the session and prefixes its output, so the
 whole loop is one terminal. The scaffolds wire this up as `bun run dev`.
-
-Watching is a behaviour of the session rather than the point of it.
-`--no-watch` still holds the connection, still streams output and still serves
-the control socket, which is what an agent driving pushes explicitly wants.
+`--no-watch` still holds the connection, streams output and serves the control
+socket, which is what an agent driving pushes explicitly wants.
 
 Every push restarts the script and costs an asset upload through the simulator,
-so the watcher is built to decide when a burst of edits has _finished_ rather
-than to react quickly: a 3s trailing debounce (`--debounce`, `--edge leading`),
-changes during a push collapsed into one follow-up rather than a queue, a
-minimum interval per item, and a rebuild that produced identical bytes ignored
-outright.
+so the watcher waits for a burst of edits to finish rather than reacting fast:
 
-A failed compile says what it left behind: the save succeeded, so the item now
-holds source that never compiled, while the previously compiled version keeps
-running.
+- A 3s trailing debounce (`--debounce`, `--edge leading`)
+- Changes during a push collapsed into one follow-up, not a queue
+- A minimum interval per item
+- A rebuild that produced identical bytes ignored outright
 
-While a session is running, the other commands go through it rather than
-opening their own connection. `--direct` opts out.
+A failed compile says what it left behind. The save succeeded, so the item holds
+source that never compiled, while the previously compiled version keeps running.
 
-### status, wait and mcp
+While a session is running, the other commands go through it rather than opening
+their own connection. `--direct` opts out.
+
+### `status`, `wait` and `mcp`
 
 `status` reports what the session is doing, `wait` blocks until a push newer
 than a given cursor settles and then reports its results with the output that
 followed, and `mcp` serves both to an agent over stdio MCP. See
 [Driving it from an agent](#driving-it-from-an-agent).
 
-### syntax
+### `syntax`
 
 Without an argument, prints the viewer's syntax id and the definition files it
 has cached. With `defs.lsl` or `defs.lua`, dumps that definition set as JSON.
 
 ## Addressing
 
-Targets are `<object>/<item>`, or `<object>/<link>/<item>` for an item in a
-child prim. The `--object`, `--link` and `--item` flags are equivalent.
-
-The object segment takes a UUID, a name, or an explicit `id:` / `name:` /
-`desc:` prefix. Items match with or without the display extension, so `Main`
-and `Main.luau` are the same item. Child prims match on link name, `Name (2)`
-when siblings share a name, link number, or UUID.
+`<object>/<item>`, or `<object>/<link>/<item>` for an item in a child prim. The
+`--object`, `--link` and `--item` flags are equivalent.
 
 ```bash
 slua-viewer push dist/main.slua 4f2b0c1e-.../Main
@@ -229,17 +184,20 @@ slua-viewer push dist/main.slua "desc:slua:my-project/Main"
 slua-viewer push dist/main.slua "My Rezzer/Panel/Main"
 ```
 
-The viewer only exposes objects it has published, so an unpublished object
-cannot be addressed. Addressing it by UUID publishes it on demand; a name or a
-description key needs the object published from the viewer first, see
-[Publishing an object](#publishing-an-object).
+The object segment takes a UUID, a name, or an explicit `id:` / `name:` /
+`desc:` prefix. Items match with or without the display extension, so `Main` and
+`Main.luau` are the same item. Child prims match on link name, `Name (2)` when
+siblings share a name, link number, or UUID.
+
+Only published objects can be addressed, and only a UUID publishes one on
+demand, see [Publishing an object](#publishing-an-object).
 
 ## A session's state
 
-`connect` keeps `.slua/` beside your `slua.json`: `session.json` (pid, socket
-path, viewer port, CLI version, removed on a clean exit) and `logs.jsonl`,
-every runtime record and push result as one JSON object per line. The log
-survives the session crashing and rotates at 5MB, keeping one previous file.
+`connect` keeps `.slua/` beside your `slua.json`. `session.json` holds the pid,
+socket path, viewer port and CLI version, and goes away on a clean exit.
+`logs.jsonl` holds every runtime record and push result as one JSON object per
+line, survives the session crashing, and rotates at 5MB keeping one old file.
 
 <Callout title="Ignore it">
   Add `.slua/` to your `.gitignore`. Projects scaffolded with `@gwigz/slua-create` already do.
@@ -249,8 +207,8 @@ survives the session crashing and rotates at 5MB, keeping one previous file.
 
 Three tiers, in order of how little integration they need.
 
-**Read the file.** `tail -n 100 .slua/logs.jsonl` needs nothing from us at all,
-and still answers after the session has gone.
+**Read the file.** `tail -n 100 .slua/logs.jsonl` needs nothing from us, and
+still answers after the session has gone.
 
 **Run the CLI.** `status`, `wait` and `logs --since` are thin wrappers over the
 session, and everything speaks `--json`:
@@ -261,10 +219,8 @@ slua-viewer wait --since 412 --for 20s
 slua-viewer logs --since 5m
 ```
 
-`wait` takes the cursor you last saw, not "the current push". Asking to wait
-for the in-flight push is only correct if one is already in flight, and usually
-none is, so that form would hand back the _previous_ run's results as though
-they were current.
+`wait` takes the cursor you last saw, not "the current push". Usually nothing is
+in flight, so that form would hand back the _previous_ run's results.
 
 **Speak MCP.** `slua-viewer mcp` is a stdio MCP server over the session's
 control socket, exposing `slua_status`, `slua_push`, `slua_wait` and
@@ -281,13 +237,12 @@ result per target and the output the restarted script produced.
 
 ### The control socket
 
-The session listens on a unix socket, a named pipe on Windows, at mode 0600 in
-your temp directory, keyed by a hash of the project root. The path is recorded
-in `.slua/session.json`.
-
-It speaks the viewer's own JSON-RPC, so a `ViewerClient` connects to a session
-exactly as it connects to the viewer and only the `control.*` namespace is new.
-Viewer calls are forwarded upstream, viewer notifications broadcast back down.
+A unix socket, or a named pipe on Windows, at mode 0600 in your temp directory,
+keyed by a hash of the project root. The path is recorded in
+`.slua/session.json`. It speaks the viewer's own JSON-RPC, so a `ViewerClient`
+connects to a session exactly as it connects to the viewer, with only the
+`control.*` namespace new. Viewer calls forward upstream, viewer notifications
+broadcast back down.
 
 <Callout type="warn" title="Local processes">
   Any local process that can reach that socket can push scripts to your viewer. That is already true
@@ -325,40 +280,37 @@ Viewer calls are forwarded upstream, viewer notifications broadcast back down.
 
 ## Compile errors
 
-`push` looks for a source map beside the file it uploads
-(`dist/main.slua.map`) and translates the viewer's Lua line numbers back to
-your original source, printing the offending line with each error. Enable it
-with `"sourceMap": true` in your tsconfig. Without a map, errors are reported
-against the generated output instead, and the CLI says so.
+`push` looks for a source map beside the file it uploads (`dist/main.slua.map`)
+and translates the viewer's Lua line numbers back to your source, printing the
+offending line with each error. Enable it with `"sourceMap": true` in your
+tsconfig. Without a map, errors point at the generated output and the CLI says
+so. Mapping is line accurate, not column accurate. LSL compile errors carry real
+column numbers, which the Luau compiler does not report.
+
+`logs` maps too. A viewer that names the item its output came from narrows that
+to the target deploying it. Without one, a line covered by more than one
+target's map is shown against every candidate, with its target name.
 
 <Callout type="warn" title="Bundled output">
   If you bundle with `@gwigz/tstl-bundle-flatten`, you need 1.2.0 or newer. Earlier versions rewrote
   the emitted Lua without updating the map, leaving it describing the unflattened bundle.
 </Callout>
 
-Mapping is line accurate, not column accurate. LSL compile errors carry real
-column numbers, which the Luau compiler does not report.
-
-`logs` maps too. A viewer that names the item its output came from narrows
-that to the target deploying it; without one, a line covered by more than one
-target's map is shown against every candidate, with its target name.
-
 ## JSON output
 
 `--json` puts exactly one JSON document on stdout and nothing else, with
-progress and errors kept on stderr, so the CLI can be piped into `jq` or read
-by an agent.
+progress and errors kept on stderr. A failure still emits a document
+(`{"ok": false, "error": "..."}`), so empty stdout always means something went
+badly wrong.
 
 ```bash
 slua-viewer push dist/main.slua --json | jq .compiled
 ```
 
-A failure still emits a document (`{"ok": false, "error": "..."}`), so an empty
-stdout always means something went badly wrong. A bounded `push --tail` keeps
-that contract by attaching what it drained to the document as `logs`. Streams
-are the exception, and emit one JSON object per line: `logs --json`, and a
-`push --json --tail` given no duration to stop at, which prints its document
-first and then streams.
+Streams are the exception and emit one JSON object per line: `logs --json`, and
+a `push --json --tail` given no duration to stop at, which prints its document
+first and then streams. A bounded `push --tail` keeps the single-document
+contract by attaching what it drained as `logs`.
 
 Keys are camelCase (`objectId`, `primId`, `itemId`, `savedBack`), matching the
 library rather than the viewer's wire format. See

--- a/apps/web/content/docs/viewer-client/index.mdx
+++ b/apps/web/content/docs/viewer-client/index.mdx
@@ -20,16 +20,15 @@ typed client for that protocol, plus a CLI so a build can deploy itself:
 bun run build && bunx @gwigz/slua-viewer-client push dist/main.slua
 ```
 
-Compile errors come back with the file and line of your **TypeScript**
-source, as long as a source map sits beside the pushed file. Without one they
-point at the generated output. A failed compile exits non-zero, so a broken
-build fails your deploy script instead of quietly shipping.
+Compile errors come back with the file and line of your TypeScript source, as
+long as a source map sits beside the pushed file, and a failed compile exits
+non-zero, so a broken build fails your deploy script instead of shipping.
 
 ## Requirements
 
 A viewer with external script editing enabled (`ExternalWebsocketSyncEnable`).
 The object you are targeting must be published to the editor first, which is a
-button in the viewer rather than a side effect of selecting it. See
+button in the viewer rather than a side effect of selecting it, see
 [Publishing an object](/docs/viewer-client/cli#publishing-an-object).
 
 ## Quick start
@@ -47,7 +46,7 @@ bunx @gwigz/slua-viewer-client objects
 ```
 
 Pair the object with a name once. Run this first, then press **"Explore in
-IDE"** in the object's Build window under Content, which is what publishes it:
+IDE"** under Content in the object's Build window, which is what publishes it:
 
 ```bash
 bunx @gwigz/slua-viewer-client link main --wait
@@ -59,18 +58,12 @@ been taken and rezzed. See [Targets](/docs/viewer-client/targets).
 
 ## Working on a script
 
-Deploying a script and working on one want different things. A script's runtime
-output reaches you as it happens or not at all. The viewer sends it to whatever
-connections are open at the moment the script speaks, buffers nothing, and the
-protocol has no way to ask for what it already sent. A command that has exited
-hears none of it, and leaves the viewer's publish button with nothing to
-publish to.
-
-That is the argument for keeping a session up. Most of what a script says
-follows a touch, a listen, a timer or an HTTP response rather than anything you
-typed. `connect` holds one connection open the whole time you are working,
-rebuilds, pushes when the output changes, and prints what your scripts say as
-you poke at them:
+Deploying a script and working on one want different things. Runtime output
+reaches whatever connections are open the moment a script speaks and nothing
+else, and most of what a script says follows a touch or a timer rather than
+anything you typed. `connect` holds one connection open the whole time you are
+working, rebuilds, pushes when the output changes, and prints what your scripts
+say as you poke at them:
 
 ```bash
 bunx @gwigz/slua-viewer-client connect --exec "bun run build:watch"
@@ -81,9 +74,8 @@ Scaffolded projects wire that up as `bun run dev`. See
 
 ## As part of a build
 
-Once deploying is part of your build, add it as a devDependency and pin it.
-Package scripts already have `node_modules/.bin` on `PATH`, so the
-`slua-viewer` bin is callable by name from there, which a bare shell cannot do:
+Add it as a devDependency and pin it. Package scripts have `node_modules/.bin`
+on `PATH`, so `slua-viewer` is callable by name there:
 
 ```bash tab="npm"
 npm install --save-dev @gwigz/slua-viewer-client
@@ -107,12 +99,10 @@ bun add -d @gwigz/slua-viewer-client
 
 ## LSL support
 
-`push`, `pull`, `reset`, `set-running` and `logs` all work on LSL scripts too,
-so a project that mixes hand-written LSL with compiled SLua needs no special
-handling.
-
-It is not an LSL toolchain though. There is no preprocessor, no `#include`
-expansion, and no LSL linting. It deploys LSL, it does not build it.
+`push`, `pull`, `reset`, `set-running` and `logs` all work on LSL scripts, so a
+project that mixes hand-written LSL with compiled SLua needs no special
+handling. It is not an LSL toolchain though. No preprocessor, no `#include`
+expansion, no linting. It deploys LSL, it does not build it.
 
 <Cards>
   <Card

--- a/apps/web/content/docs/viewer-client/index.mdx
+++ b/apps/web/content/docs/viewer-client/index.mdx
@@ -57,6 +57,28 @@ That stamps a `slua:main` key into the object's description and records the
 target in `slua.json`, so later deploys find the object again even after it has
 been taken and rezzed. See [Targets](/docs/viewer-client/targets).
 
+## Working on a script
+
+Deploying a script and working on one want different things. A script's runtime
+output reaches you as it happens or not at all. The viewer sends it to whatever
+connections are open at the moment the script speaks, buffers nothing, and the
+protocol has no way to ask for what it already sent. A command that has exited
+hears none of it, and leaves the viewer's publish button with nothing to
+publish to.
+
+That is the argument for keeping a session up. Most of what a script says
+follows a touch, a listen, a timer or an HTTP response rather than anything you
+typed. `connect` holds one connection open the whole time you are working,
+rebuilds, pushes when the output changes, and prints what your scripts say as
+you poke at them:
+
+```bash
+bunx @gwigz/slua-viewer-client connect --exec "bun run build:watch"
+```
+
+Scaffolded projects wire that up as `bun run dev`. See
+[connect](/docs/viewer-client/cli#connect).
+
 ## As part of a build
 
 Once deploying is part of your build, add it as a devDependency and pin it.

--- a/apps/web/content/docs/viewer-client/library.mdx
+++ b/apps/web/content/docs/viewer-client/library.mdx
@@ -4,8 +4,8 @@ description: Typed client, runtime events, and target resolution
 icon: Code2
 ---
 
-Everything the CLI does is available as a library, so a custom deploy script
-can reuse the same protocol handling, addressing, and target precedence.
+Everything the CLI does is available as a library, with the same protocol
+handling, addressing and target precedence.
 
 ```bash tab="npm"
 npm install --save-dev @gwigz/slua-viewer-client
@@ -58,7 +58,7 @@ the `commands` option.
 
 ## Methods
 
-`ViewerClient` wraps the protocol's methods, each named after the RPC it sends:
+Each method is named after the RPC it sends:
 
 | Area     | Methods                                                            |
 | -------- | ------------------------------------------------------------------ |
@@ -88,13 +88,12 @@ client.on("runtime.error", (event) => console.error(event.objectName, event.mess
 ```
 
 `on` returns an unsubscribe function, and `runtime.debug` carries the script's
-non-error output. A viewer advertising the `unifiedDiagnostics` feature fills in
-`error`, `line` and an `item` reference naming the script; older ones leave
-`error` empty and `line` 0, and send the text as a separate `runtime.debug`
-message. `line` is 0 on any viewer when the error names no line.
+non-error output. A viewer advertising `unifiedDiagnostics` fills in `error`,
+`line` and an `item` reference naming the script. Older ones leave `error` empty
+and `line` 0, and send the text as a separate `runtime.debug` message. `line` is
+0 on any viewer when the error names no line.
 
-`ensurePublished` and `resolveItem` take options for the two things the viewer
-makes awkward:
+`ensurePublished` and `resolveItem` take options for the awkward parts:
 
 | Option      | Effect                                                                  |
 | ----------- | ----------------------------------------------------------------------- |
@@ -107,8 +106,7 @@ viewer's published inventory goes briefly stale right after a save.
 
 ## Target resolution
 
-Target resolution is exported too, so a custom deploy script can reuse the same
-precedence rules:
+Target resolution is exported too:
 
 ```ts
 import { loadConfig, readHeaderTagsFor, resolveTarget } from "@gwigz/slua-viewer-client"
@@ -124,8 +122,8 @@ const target = resolveTarget({
 ```
 
 `readHeaderTagsFor` follows the source map beside a built file back to the
-source that produced it, so header tags work on bundled output. `loadSourceMapFor`
-and `SourceMap.mapRow` are exported for mapping Lua rows to source locations
+source that produced it, so header tags work on bundled output.
+`loadSourceMapFor` and `SourceMap.mapRow` are exported for mapping Lua rows
 yourself.
 
 ## Errors
@@ -142,9 +140,8 @@ Failures throw typed errors rather than plain strings:
 
 ## Naming
 
-The viewer's protocol is snake_case. Everything this package exposes is
-camelCase, converted once at the JSON-RPC boundary, so `object_id` on the wire
-is `objectId` in your code and in `--json` output.
-
-Only field-shaped keys convert. Keys carrying data, an item named `Main` or an
-object named `Door Control`, pass through untouched.
+The viewer's protocol is snake_case, and everything this package exposes is
+camelCase, converted once at the JSON-RPC boundary. So `object_id` on the wire
+is `objectId` in your code and in `--json` output. Only field-shaped keys
+convert. Keys carrying data, an item named `Main` or an object named
+`Door Control`, pass through untouched.

--- a/apps/web/content/docs/viewer-client/targets.mdx
+++ b/apps/web/content/docs/viewer-client/targets.mdx
@@ -10,10 +10,9 @@ trip, which makes a description key the durable way to pair.
 
 ## Precedence
 
-There are three places a destination can come from, in order of precedence:
-**command line flags, then `slua.json`, then the source header**. The header is
-the default a script ships with, config retargets a build for a different
-environment without touching source.
+A destination comes from command line flags, then `slua.json`, then the source
+header. The header is the default a script ships with, and config retargets a
+build for another environment without touching source.
 
 ## `link`
 
@@ -25,25 +24,21 @@ key, however many times it has been rezzed.
 slua-viewer link main --wait
 ```
 
-The object has to be published first, which is the Content tab's **"Explore in
-IDE"** button rather than the selection, see
-[Publishing an object](/docs/viewer-client/cli#publishing-an-object). With
-`--wait` the command holds the connection open so that button has somewhere to
-publish to. If several objects are published, name one with `--object`. Pass
-`--key` to pair on something other than `slua:<name>`, and `--file` to record an
-output path other than `dist/<name>.slua`.
+The object has to be published first, and `--wait` holds the connection open so
+the viewer's button has somewhere to publish to, see
+[Publishing an object](/docs/viewer-client/cli#publishing-an-object). Name one
+with `--object` if several are published, `--key` to pair on something other
+than `slua:<name>`, and `--file` to record an output path other than
+`dist/<name>.slua`.
 
-The key is appended to whatever description the object already has, matched on
-a word boundary so `slua:main` is not confused with `slua:main-menu`.
-Descriptions cap at 127 bytes of UTF-8 in Second Life, so a multi-byte
-character costs more than one, and a full description is reported rather than
-truncated. Linking warns, but still writes, when the object has no
-item of that name yet.
+The key is appended to the object's existing description, matched on a word
+boundary so `slua:main` is not confused with `slua:main-menu`. Descriptions cap
+at 127 bytes of UTF-8, and a full one is reported rather than truncated. Linking
+warns, but still writes, when the object has no item of that name yet.
 
 ## Source headers
 
-A script can declare its own destination, so a small project needs no config at
-all:
+A script can declare its own destination, so a small project needs no config:
 
 ```ts
 /**
@@ -63,18 +58,15 @@ all:
 | `@slua-save-back`              | Derez back into the source prim after a successful push      |
 
 `@slua-save-back` needs no value, but takes one, so `@slua-save-back false`
-turns it off where something else would have enabled it.
+turns it off where something else enabled it. An unknown tag is an error, which
+catches a typo before it deploys somewhere unintended.
 
-A tag the parser does not know is an error, which catches a typo before it
-deploys somewhere unintended.
-
-For a compiled bundle the tags are read from the source it came from, found
-through the source map. A hand-written script is its own source, so a `.lsl` or
-`.luau` file carries its header directly.
-
-When several sources behind one bundle carry tags, the entry point wins, since
-TSTL emits it last. Unknown tags are tolerated during that sweep rather than
-failing the push, because the sources include vendored code you did not write.
+For a compiled bundle the tags come from the source it was built from, found
+through the source map, and the entry point wins when several sources carry
+them, since TSTL emits it last. Unknown tags are tolerated during that sweep
+rather than failing the push, since those sources include vendored code you did
+not write. A hand-written `.lsl` or `.luau` file is its own source and carries
+its header directly.
 
 Both comment syntaxes work (`//`, `/* */`, `--`, `--[[ ]]`), and tags are only
 honoured above the first line of code, so a `@slua-` string appearing later
@@ -122,13 +114,12 @@ file's base name as the target name.
 
 ## Saving back to a rezzer
 
-`saveBack` derezzes the object into the prim it was rezzed from, which is how
-you update a rezzer's payload without the take-and-replace dance.
+`saveBack` derezzes the object into the prim it was rezzed from, which updates a
+rezzer's payload without the take-and-replace dance.
 
-The viewer only offers this for an object rezzed out of another in-world prim's
-contents, and it decides that when the object is published. An object published
-by UUID alone reports `canSaveBack: false`, and the push reports the save-back
-as failed.
+The viewer only offers it for an object rezzed out of another in-world prim's
+contents, decided when the object is published. One published by UUID alone
+reports `canSaveBack: false`, and the push reports the save-back as failed.
 
 <Callout type="warn" title="Inventory objects">
   An object sitting in your own inventory cannot be reached at all. It has to be rezzed.

--- a/packages/create/src/templates/common.ts
+++ b/packages/create/src/templates/common.ts
@@ -1,6 +1,7 @@
 export const GITIGNORE = `node_modules/
 dist/
 out/
+.slua/
 `
 
 export const VSCODE_SETTINGS = `{

--- a/packages/create/src/templates/multi.ts
+++ b/packages/create/src/templates/multi.ts
@@ -23,6 +23,7 @@ export function generateMultiTemplate(options: ProjectOptions): Record<string, s
   const devDependencies: Record<string, string> = {
     "@gwigz/slua-tstl-plugin": VERSIONS["@gwigz/slua-tstl-plugin"],
     "@gwigz/slua-types": VERSIONS["@gwigz/slua-types"],
+    "@gwigz/slua-viewer-client": VERSIONS["@gwigz/slua-viewer-client"],
     "@gwigz/tstl-bundle-flatten": VERSIONS["@gwigz/tstl-bundle-flatten"],
     "@typescript-to-lua/language-extensions": VERSIONS["@typescript-to-lua/language-extensions"],
     "@types/node": VERSIONS["@types/node"],
@@ -56,7 +57,10 @@ export function generateMultiTemplate(options: ProjectOptions): Record<string, s
 
   const scripts: Record<string, string> = {
     build: `${run} build.ts`,
-    dev: `${run} build.ts --watch`,
+    // One command to learn: the session runs the watch build, pushes what it
+    // produces and tails the script's output, in one terminal.
+    dev: `slua-viewer connect --exec "${run} build.ts --watch"`,
+    "build:watch": `${run} build.ts --watch`,
   }
 
   if (extras.linting) {

--- a/packages/create/src/templates/single.ts
+++ b/packages/create/src/templates/single.ts
@@ -20,6 +20,7 @@ export function generateSingleTemplate(options: ProjectOptions): Record<string, 
   const devDependencies: Record<string, string> = {
     "@gwigz/slua-tstl-plugin": VERSIONS["@gwigz/slua-tstl-plugin"],
     "@gwigz/slua-types": VERSIONS["@gwigz/slua-types"],
+    "@gwigz/slua-viewer-client": VERSIONS["@gwigz/slua-viewer-client"],
     "@gwigz/tstl-bundle-flatten": VERSIONS["@gwigz/tstl-bundle-flatten"],
     "@typescript-to-lua/language-extensions": VERSIONS["@typescript-to-lua/language-extensions"],
     "darklua-wasm": VERSIONS["darklua-wasm"],
@@ -48,7 +49,10 @@ export function generateSingleTemplate(options: ProjectOptions): Record<string, 
 
   const scripts: Record<string, string> = {
     build: "tstl -p tsconfig.json",
-    dev: "tstl -p tsconfig.json --watch",
+    // One command to learn: the session runs the watch build, pushes what it
+    // produces and tails the script's output, in one terminal.
+    dev: 'slua-viewer connect --exec "tstl -p tsconfig.json --watch"',
+    "build:watch": "tstl -p tsconfig.json --watch",
   }
 
   if (extras.stylua) {

--- a/packages/create/src/templates/single.ts
+++ b/packages/create/src/templates/single.ts
@@ -56,7 +56,7 @@ export function generateSingleTemplate(options: ProjectOptions): Record<string, 
   }
 
   if (extras.stylua) {
-    scripts.format = "stylua --syntax luau out/"
+    scripts.format = "stylua --syntax luau dist/"
   }
   if (extras.linting) {
     scripts.lint = "oxlint --type-aware"
@@ -93,7 +93,9 @@ export function generateSingleTemplate(options: ProjectOptions): Record<string, 
     lib: ["ESNext"],
     types: ["@typescript-to-lua/language-extensions", "@gwigz/slua-types"],
     rootDir: ".",
-    outDir: "out",
+    // Matches what "slua-viewer link" records, so the session started by
+    // "dev" resolves the target its watch build writes.
+    outDir: "dist",
   }
 
   if (extras.jsx) {

--- a/packages/create/src/templates/templates.test.ts
+++ b/packages/create/src/templates/templates.test.ts
@@ -30,7 +30,25 @@ describe("single template", () => {
     const pkg = JSON.parse(generateSingleTemplate(options())["package.json"])
 
     expect(pkg.scripts.build).toBe("tstl -p tsconfig.json")
-    expect(pkg.scripts.dev).toBe("tstl -p tsconfig.json --watch")
+
+    // dev is the viewer session, which runs the watch build inside it, so
+    // there is one command rather than two terminals and an explanation.
+    expect(pkg.scripts.dev).toBe('slua-viewer connect --exec "tstl -p tsconfig.json --watch"')
+    expect(pkg.scripts["build:watch"]).toBe("tstl -p tsconfig.json --watch")
+    expect(pkg.devDependencies["@gwigz/slua-viewer-client"]).toBeDefined()
+  })
+
+  it("gives the multi template the same session entry point", () => {
+    const pkg = JSON.parse(generateMultiTemplate(options({ template: "multi" }))["package.json"])
+
+    expect(pkg.scripts.dev).toBe('slua-viewer connect --exec "bun build.ts --watch"')
+    expect(pkg.scripts["build:watch"]).toBe("bun build.ts --watch")
+    expect(pkg.devDependencies["@gwigz/slua-viewer-client"]).toBeDefined()
+  })
+
+  it("ignores the session state directory", () => {
+    expect(generateSingleTemplate(options())[".gitignore"]).toContain(".slua/")
+    expect(generateMultiTemplate(options({ template: "multi" }))[".gitignore"]).toContain(".slua/")
   })
 
   it("bundles with require-minimal and the flatten plugin", () => {

--- a/packages/create/src/templates/versions.ts
+++ b/packages/create/src/templates/versions.ts
@@ -4,6 +4,7 @@ export const VERSIONS = {
   "@typescript-to-lua/language-extensions": "^1.19.0",
   "@gwigz/slua-tstl-plugin": "^1.8.0",
   "@gwigz/slua-types": "^1.4.3",
+  "@gwigz/slua-viewer-client": "^0.1.0",
   "@gwigz/tstl-bundle-flatten": "^1.2.0",
   "darklua-wasm": "^0.1.0",
   "@gwigz/jsx-inline": "^1.1.0",

--- a/packages/viewer-client/README.md
+++ b/packages/viewer-client/README.md
@@ -75,7 +75,7 @@ Examples below use the `slua-viewer` bin name, which resolves inside a package s
 
 A save restarts the script, so whatever its `state_entry` says is on the wire within milliseconds, and a command that disconnects as soon as the save returns never sees it. `push` keeps listening for a moment (1.5s) and prints what arrives under the compile result:
 
-```
+```text
 compiled Main.luau in My Rezzer
 say My Rezzer/Main  ready
 ```

--- a/packages/viewer-client/README.md
+++ b/packages/viewer-client/README.md
@@ -63,9 +63,26 @@ bun run deploy
 | `reset <object>/<item>`               | Reset a script                               |
 | `set-running on\|off <object>/<item>` | Start or stop a script                       |
 | `logs`                                | Stream runtime output from published objects |
+| `connect`                             | Hold a session: watch, push and tail in one  |
+| `status`                              | What the running session is doing            |
+| `wait`                                | Block until the next push settles            |
+| `mcp`                                 | Serve the session to an agent over MCP       |
 | `syntax [defs.lsl\|defs.lua]`         | Dump language definitions                    |
 
 Examples below use the `slua-viewer` bin name, which resolves inside a package script or after a devDependency install. Prefix them with `bunx @gwigz/slua-viewer-client` to run them straight from a shell.
+
+### Output after a push
+
+A save restarts the script, so whatever its `state_entry` says is on the wire within milliseconds, and a command that disconnects as soon as the save returns never sees it. `push` keeps listening for a moment (1.5s) and prints what arrives under the compile result:
+
+```
+compiled Main.luau in My Rezzer
+say My Rezzer/Main  ready
+```
+
+`--tail 10s` widens the window, `--tail` on its own keeps listening until you interrupt it, and `--no-tail` skips it for scripted use. Only output from the object and item just pushed is shown. The result payload carries a `cursor`, which is the point everything the push caused comes after.
+
+A bounded window only covers the restart. Whatever the script says afterwards, when someone touches it or a timer fires, needs a connection that is still open. That is [a session](#a-session), or `logs --follow`.
 
 ### Addressing
 
@@ -81,27 +98,113 @@ slua-viewer push dist/main.slua "My Rezzer/Panel/Main"
 
 ### Options
 
-| Flag                  | Applies to     | Meaning                                              |
-| --------------------- | -------------- | ---------------------------------------------------- |
-| `--object <id\|name>` | most           | Target object, same grammar as the object segment    |
-| `--item <id\|name>`   | most           | Target inventory item                                |
-| `--link <id\|name>`   | most           | Child prim within the linkset                        |
-| `--vm <vm>`           | `push`         | Compile target: `luau`, `mono`, `lsl2`               |
-| `--target <name>`     | `push`         | Deploy a named target from `slua.json`               |
-| `--all`               | `push`         | Deploy every target in `slua.json`                   |
-| `--save-back`         | `push`         | Derez back into the source prim after a good compile |
-| `--file <path>`       | `push`, `link` | File to push, or to record when linking              |
-| `--key <key>`         | `link`         | Description key to pair on, default `slua:<name>`    |
-| `-f`, `--follow`      | `logs`         | Keep streaming, reconnecting if the viewer restarts  |
-| `--targets`           | `logs`         | Only output from items your `slua.json` targets      |
-| `--wait`              | most           | Hold the viewer connection open until it publishes   |
-| `--port <port>`       | all            | Viewer websocket port, default `9020`                |
-| `--timeout <ms>`      | all            | Request timeout                                      |
-| `--json`              | all            | Machine-readable output on stdout                    |
+| Flag                         | Applies to     | Meaning                                               |
+| ---------------------------- | -------------- | ----------------------------------------------------- |
+| `--object <id\|name>`        | most           | Target object, same grammar as the object segment     |
+| `--item <id\|name>`          | most           | Target inventory item                                 |
+| `--link <id\|name>`          | most           | Child prim within the linkset                         |
+| `--vm <vm>`                  | `push`         | Compile target: `luau`, `mono`, `lsl2`                |
+| `--target <name>`            | `push`         | Deploy a named target from `slua.json`                |
+| `--all`                      | `push`         | Deploy every target in `slua.json`                    |
+| `--save-back`                | `push`         | Derez back into the source prim after a good compile  |
+| `--file <path>`              | `push`, `link` | File to push, or to record when linking               |
+| `--key <key>`                | `link`         | Description key to pair on, default `slua:<name>`     |
+| `-f`, `--follow`             | `logs`         | Keep streaming, reconnecting if the viewer restarts   |
+| `--targets`                  | `logs`         | Only output from items your `slua.json` targets       |
+| `--tail [duration]`          | `push`         | Keep listening after the push, `5s`, or until ctrl-c  |
+| `--no-tail`                  | `push`         | Push without waiting for output at all                |
+| `--watch`/`--no-watch`       | `connect`      | Push when a target's output changes, on by default    |
+| `--debounce <ms>`            | `connect`      | How long a target must be quiet first, default `3000` |
+| `--edge <edge>`              | `connect`      | `trailing` (default) or `leading`                     |
+| `--exec <command>`           | `connect`      | Run a build alongside the session                     |
+| `--since <cursor\|duration>` | `logs`, `wait` | Output after a cursor, or from the last `5m`          |
+| `--for <duration>`           | `wait`         | How long to block, default `30s`                      |
+| `--direct`                   | all            | Talk to the viewer even with a session running        |
+| `--wait`                     | most           | Hold the viewer connection open until it publishes    |
+| `--port <port>`              | all            | Viewer websocket port, default `9020`                 |
+| `--timeout <ms>`             | all            | Request timeout                                       |
+| `--json`                     | all            | Machine-readable output on stdout                     |
 
 Keys in `--json` output are camelCase (`objectId`, `primId`, `itemId`, `savedBack`), matching the library rather than the viewer's wire format. See [Naming](#naming).
 
-Under `--json`, stdout carries exactly one JSON document and nothing else, with progress and errors kept on stderr. A failure still emits a document (`{"ok": false, "error": "..."}`), so an empty stdout always means something went badly wrong. `logs --json` is the exception: it emits one JSON object per line, since it is a stream.
+Under `--json`, stdout carries exactly one JSON document and nothing else, with progress and errors kept on stderr. A failure still emits a document (`{"ok": false, "error": "..."}`), so an empty stdout always means something went badly wrong. Streams are the exception, and emit one JSON object per line: `logs --json`, and `push --json --tail` given no duration to stop at, which prints its document first and then streams.
+
+## A session
+
+`push` and `logs` each connect, do one thing and let go. `connect` stays, which is what the viewer expects. It publishes objects to whichever editor client is attached at the time, and it sends runtime output only to connections that are open at the moment a script speaks. Nothing is buffered, and the protocol has no way to ask for what it already sent, so a line spoken with nothing connected is gone.
+
+Most of what a script says follows a touch, a listen, a timer or an HTTP response rather than anything you typed. A session still holding the connection hears all of it, and lets you press "Explore in IDE" on a new object whenever you like. A command that exited hears nothing and publishes nothing.
+
+A session is one viewer connection, watching the built outputs your `slua.json` names, pushing when they change, and printing what your scripts say for as long as you keep it open.
+
+```bash
+slua-viewer connect --exec "bun run build:watch"
+```
+
+That is one terminal for the whole loop. `--exec` runs your build inside the session and prefixes its output, so there is no second window to keep an eye on. The scaffolds wire this up as `bun run dev`.
+
+Watching is a behaviour of the session, not the point of it. `--no-watch` still holds the connection, still streams output and still serves the control socket, which is what an agent driving pushes explicitly wants.
+
+Every push restarts the script and costs an asset upload through the simulator, so the watcher is built to decide when a burst of edits has **finished** rather than to react quickly:
+
+| Guard             | What it does                                                            |
+| ----------------- | ----------------------------------------------------------------------- |
+| Debounce, 3s      | A burst of saves becomes one push. `--debounce <ms>` to tune            |
+| Trailing edge     | Fires after the quiet, not on the first write. `--edge leading` to swap |
+| Coalescing        | Changes during a push collapse into one follow-up, never a queue        |
+| Minimum interval  | The same item is not pushed again within a few seconds, and says so     |
+| Identical content | A rebuild that changed nothing does not restart a running script        |
+
+A failed compile is reported loudly, and says what it left behind: the save succeeded, so the item now holds source that never compiled, while the previously compiled version keeps running.
+
+### Session state
+
+`connect` keeps `.slua/` beside your `slua.json`:
+
+| File                 | What it is                                                          |
+| -------------------- | ------------------------------------------------------------------- |
+| `.slua/session.json` | pid, socket path, viewer port, CLI version. Removed on a clean exit |
+| `.slua/logs.jsonl`   | Every runtime record and push result, one JSON object per line      |
+
+The log survives the session crashing, which is exactly when you want to read it. It rotates at 5MB, keeping one previous file. Add `.slua/` to your `.gitignore`; the scaffolds already do.
+
+While a session is running, the other commands go through it rather than opening their own connection, so they share its viewer connection and its cursor. `--direct` opts out.
+
+## Driving it from an agent
+
+Three tiers, in order of how little integration they need.
+
+**Read the file.** `tail -n 100 .slua/logs.jsonl` needs nothing from us at all, and works after the session has gone.
+
+**Run the CLI.** `status`, `wait` and `logs --since` are thin wrappers over the session, and everything speaks `--json`:
+
+```bash
+slua-viewer status --json
+slua-viewer wait --since 412 --for 20s      # blocks until a push newer than 412 settles
+slua-viewer logs --since 5m                  # from the session, or from its log if it has gone
+```
+
+`wait` takes the cursor you last saw, not "the current push". Asking to wait for the in-flight push is only correct if one is already in flight, and it usually is not, so that form would happily hand back the **previous** run's results as though they were current.
+
+**Speak MCP.** `slua-viewer mcp` is a stdio MCP server over the same socket, with `slua_status`, `slua_push`, `slua_wait` and `slua_logs`. `slua_push` pushes and waits in one call, returning the compile result per target and the output the restarted script produced.
+
+```jsonc
+{
+  "mcpServers": {
+    "slua": { "command": "slua-viewer", "args": ["mcp"], "cwd": "/path/to/project" },
+  },
+}
+```
+
+It needs a session running; with none it says so rather than guessing.
+
+### The control socket
+
+The session listens on a unix socket (a named pipe on Windows) at mode 0600, in your temp directory, keyed by a hash of the project root. The path is recorded in `.slua/session.json`.
+
+It speaks the viewer's own JSON-RPC, so `ViewerClient` connects to a session exactly as it connects to the viewer, and only the `control.*` namespace is new. Viewer calls are forwarded upstream and viewer notifications are broadcast back down.
+
+> Any local process that can reach that socket can push scripts to your viewer. That is already true of port 9020 itself, which is why the socket is not a new exposure, but it is worth knowing.
 
 ## Publishing an object
 
@@ -198,6 +301,8 @@ An object sitting in your own inventory cannot be reached at all. It has to be r
 ## Mapping errors back to TypeScript
 
 `push` looks for a source map beside the file it uploads (`dist/main.slua.map`) and translates the viewer's Lua line numbers back to your original source. Enable it with `"sourceMap": true` in your tsconfig. Without a map, errors are reported against the generated output instead.
+
+Drained output maps the same way, so a `push` shows its script's first lines already annotated with the TypeScript they came from.
 
 `logs` maps too. Runtime output reports positions in the generated Lua (`lua_script:5`), so each line is annotated with the TypeScript it came from, using the source maps of the targets in your `slua.json`. A viewer that names the item its output came from narrows that to the target deploying it, and labels each line `object/item`; without one, a line covered by more than one target's map is shown against every candidate, with its target name.
 

--- a/packages/viewer-client/scripts/mock-viewer.ts
+++ b/packages/viewer-client/scripts/mock-viewer.ts
@@ -121,6 +121,23 @@ async function handle(ws: any, message: any): Promise<void> {
 
       if (process.env.MOCK_STALE_SAVE === "1") staleReads = 2
 
+      // A save restarts the script, so its startup output follows immediately.
+      // That is the gap `push --tail` drains.
+      setTimeout(() => {
+        send(ws, {
+          jsonrpc: "2.0",
+          method: "runtime.debug",
+          params: {
+            script_id: "",
+            object_id: OBJECT_ID,
+            object_name: object.object_name,
+            item: { root_id: OBJECT_ID, name: "Main" },
+            channel: "owner_say",
+            message: "hello from state_entry",
+          },
+        })
+      }, 150)
+
       return result(ws, id, {
         success: true,
         prim_id: params.prim_id,

--- a/packages/viewer-client/src/addressing.test.ts
+++ b/packages/viewer-client/src/addressing.test.ts
@@ -415,7 +415,7 @@ describe("listPublished", () => {
 describe("resolveItem", () => {
   it("retries a listing that is briefly stale after a save", async () => {
     // The viewer drops the object, then the item, from object.list for a
-    // moment after a content save; both settle within a couple of reads.
+    // moment after a content save. Both settle within a couple of reads.
     const listings = [[], [{ ...object, inventory: [] }], [object]]
 
     let calls = 0

--- a/packages/viewer-client/src/addressing.ts
+++ b/packages/viewer-client/src/addressing.ts
@@ -16,10 +16,9 @@ export function isUuid(value: string): boolean {
 /**
  * How to find an object.
  *
- * A UUID is the most direct but the least durable: taking an object and
- * rezzing it again gives it a new one. Name and description survive that
- * round trip, which makes a description key the stable way to pin a project
- * to an object.
+ * Taking an object and rezzing it again gives it a new UUID. Name and
+ * description survive that round trip, so a description key is the stable way
+ * to pin a project to an object.
  */
 export type ObjectSelector =
   | { kind: "id"; value: string }
@@ -27,10 +26,8 @@ export type ObjectSelector =
   | { kind: "description"; value: string }
 
 /**
- * Parses an object selector.
- *
- * A bare value is a UUID if it looks like one and a name otherwise; the
- * `id:`, `name:` and `desc:` prefixes make the choice explicit.
+ * A bare value is a UUID if it looks like one and a name otherwise. The `id:`,
+ * `name:` and `desc:` prefixes make the choice explicit.
  */
 export function parseObjectSelector(raw: string): ObjectSelector {
   for (const [prefix, kind] of [
@@ -53,11 +50,9 @@ export function parseObjectSelector(raw: string): ObjectSelector {
 /**
  * Matches a description key on whitespace boundaries.
  *
- * A plain substring test would let the key `slua:main` match an object
- * described `slua:main-menu`, so any two targets where one name prefixes the
- * other would resolve to the same prim. Keys are stamped space separated
- * alongside whatever else the description holds, so a boundary either side is
- * what tells one apart from the next.
+ * A substring test would let `slua:main` match an object described
+ * `slua:main-menu`, so any two targets where one name prefixes the other would
+ * resolve to the same prim.
  */
 export function descriptionMatches(description: string, value: string): boolean {
   if (value === "") return false
@@ -93,9 +88,8 @@ export interface ObjectRef {
 /**
  * Parses `<object>/<item>` or `<object>/<link>/<item>`.
  *
- * `<object>` is an object selector, `<link>` accepts a UUID, link name or link
- * number, and `<item>` accepts an item UUID or its display name (with or
- * without the synthetic extension).
+ * `<link>` accepts a UUID, link name or link number. `<item>` accepts an item
+ * UUID or its display name, with or without the synthetic extension.
  */
 export function parseObjectRef(ref: string): ObjectRef {
   const parts = ref.split("/").filter((part) => part !== "")
@@ -114,8 +108,8 @@ export function parseObjectRef(ref: string): ObjectRef {
 /**
  * The extension the viewer's file view shows for an item.
  *
- * It is synthetic — the SL inventory name never contains it — so it is only
- * ever added for display and tolerated on input.
+ * Synthetic: the SL inventory name never contains it, so it is added for
+ * display and tolerated on input.
  */
 export function displayExtension(item: ObjectInventoryItem): string {
   if (item.type !== "script") return ""
@@ -166,7 +160,6 @@ export function eachPrim(
   ]
 }
 
-/** Finds an item within an already-published object. */
 export function findItem(object: PublishedObject, ref: ObjectRef): ResolvedItem {
   if (ref.link !== undefined) {
     const links = object.linkedObjects ?? []
@@ -198,7 +191,6 @@ export function findItem(object: PublishedObject, ref: ObjectRef): ResolvedItem 
   throw new Error(`no item "${ref.item}" in ${object.objectName}`)
 }
 
-/** Whether a published object answers to a selector. */
 export function matchesSelector(object: PublishedObject, selector: ObjectSelector): boolean {
   switch (selector.kind) {
     case "id":
@@ -222,11 +214,10 @@ function findPublished(
 /**
  * What actually publishes an object to us.
  *
- * Selecting an object does nothing on its own: publishing is the Content tab's
- * "Explore in IDE" button, and the viewer only publishes there when an editor
- * client is already connected — with none, it launches an external editor
- * instead. So the connection has to be waiting before the button is pressed,
- * which is what `--wait` is for.
+ * Selecting an object does nothing. Publishing is the Content tab's "Explore
+ * in IDE" button, and the viewer only publishes there when an editor client is
+ * already connected. With none it launches an external editor instead, so the
+ * connection has to be waiting before the button is pressed. That is `--wait`.
  */
 export const PUBLISH_ACTION =
   'open the object\'s Build window, go to Content and press "Explore in IDE"'
@@ -244,21 +235,20 @@ export const PUBLISH_WAIT_MS = 300_000
 /**
  * Delays before re-reading the object list.
  *
- * The viewer's published inventory goes briefly stale right after a content
- * save: the item, and sometimes the whole object, drops out of `object.list`
- * for a moment before settling. A second look succeeds, so this short ladder
- * is the difference between `push --all` working and failing on whichever
- * target follows a save.
+ * Right after a content save the item, and sometimes the whole object, drops
+ * out of `object.list` for a moment. A second look succeeds, which is the
+ * difference between `push --all` working and failing on whichever target
+ * follows a save.
  */
 const LOOKUP_RETRY_MS = [150, 300, 600]
 
 /**
  * Whether an error is the viewer's prim inventory still settling.
  *
- * The same window that empties a listing also makes a call naming the item
- * fail: `object.content.save` comes back as invalid params with "Item not
- * found in prim inventory", though the item is there and its id has not
- * changed. Seen roughly one push in five when pushing repeatedly.
+ * The window that empties a listing also fails a call naming the item.
+ * `object.content.save` comes back as invalid params with "Item not found in
+ * prim inventory" though the item is there and its id has not changed. Roughly
+ * one push in five when pushing repeatedly.
  */
 export function isStaleInventory(error: unknown): boolean {
   return (
@@ -353,7 +343,6 @@ function waitForPublish(client: ViewerClient, selector: ObjectSelector, timeoutM
   )
 }
 
-/** A publish subscription, and the means to drop it again. */
 export interface PublishWatcher {
   published: Promise<PublishedObject>
   cancel: () => void
@@ -375,8 +364,7 @@ export function waitForAnyPublish(client: ViewerClient, timeoutMs: number): Publ
  *
  * The viewer only publishes to a client that is already connected, so an empty
  * listing under `--wait` means waiting for the publish button rather than
- * giving up. The watcher subscribes before the listing that decides whether to
- * wait, since a publish landing between the two would otherwise be missed.
+ * giving up.
  */
 export async function listPublished(
   client: ViewerClient,
@@ -386,8 +374,9 @@ export async function listPublished(
 
   const { published, cancel } = waitForAnyPublish(client, options.waitMs)
 
-  // Nothing awaits it when the listing is already populated, so swallow the
-  // timeout rather than leave it unhandled.
+  // Subscribed before the listing that decides whether to wait, or a publish
+  // landing between the two would be missed. Nothing awaits it when the
+  // listing turns out to be populated, so swallow the timeout.
   published.catch(() => {})
 
   let list: PublishedObject[]
@@ -410,7 +399,7 @@ export async function listPublished(
 
   const object = await published
 
-  // Re-list rather than trust the one notification: a publish can carry
+  // Re-list rather than trust the one notification. A publish can carry
   // several objects, and the listing is what callers read.
   const settled = (await client.objectList()).objects ?? []
 
@@ -428,17 +417,15 @@ export async function ensurePublished(
   selector: ObjectSelector,
   options: PublishOptions = {},
 ): Promise<PublishedObject> {
-  // Under --wait the watcher subscribes before the listing that decides
-  // whether to wait, since a publish landing between the two would be missed.
-  // Only a UUID can be requested; the viewer has no way to look an object up
-  // by name or description, so those have to be published from the viewer.
+  // Only a UUID can be requested. The viewer cannot look an object up by name
+  // or description, so those come from the publish button. The watcher goes on
+  // before the listing, or a publish landing between the two is missed.
   const waiting =
     selector.kind !== "id" && options.waitMs
       ? waitForPublish(client, selector, options.waitMs)
       : undefined
 
-  // Nothing awaits it when the listing already has the object, so swallow the
-  // timeout rather than leave it unhandled.
+  // Nothing awaits it when the listing already has the object.
   waiting?.published.catch(() => {})
 
   let objects: PublishedObject[] | undefined
@@ -473,16 +460,16 @@ export async function ensurePublished(
 
   const objectId = selector.value
 
-  // Newer viewers answer object.request with the object inline; older ones
+  // Newer viewers answer object.request with the object inline. Older ones
   // acknowledge and follow up with an object.publish notification. Listen
-  // before asking, so a fast notification cannot arrive before we are ready.
+  // before asking, or a fast notification arrives before we are ready.
   const { published, cancel } = waitForPublish(
     client,
     selector,
     options.timeoutMs ?? REQUEST_TIMEOUT_MS,
   )
 
-  // Nothing awaits `published` on the inline path, so swallow its rejection.
+  // Nothing awaits it on the inline path.
   published.catch(() => {})
 
   try {
@@ -523,7 +510,7 @@ export async function resolveItem(
 ): Promise<ResolvedItem> {
   for (let attempt = 0; ; attempt++) {
     try {
-      // Only the first attempt waits on the viewer: the retries exist for a
+      // Only the first attempt waits on the viewer. The retries are for a
       // listing that settles in milliseconds, not for a missing object.
       const object = await ensurePublished(
         client,

--- a/packages/viewer-client/src/cli/args.test.ts
+++ b/packages/viewer-client/src/cli/args.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test"
-import { CliUsageError, helpText, parseCliArgs } from "./args"
+import { CliUsageError, DRAIN_MS, helpText, parseCliArgs } from "./args"
 
 describe("parseCliArgs", () => {
   it("defaults to help with no arguments", () => {
@@ -70,7 +70,33 @@ describe("parseCliArgs", () => {
       target: undefined,
       all: false,
       saveBack: undefined,
+      tail: DRAIN_MS,
     })
+  })
+
+  it("drains for a short window by default, and not at all with --no-tail", () => {
+    // A plain push loses the output its own save produced without this.
+    expect(parseCliArgs(["push", "dist/main.slua"]).command).toMatchObject({ tail: DRAIN_MS })
+    expect(parseCliArgs(["push", "dist/main.slua", "--no-tail"]).command).toMatchObject({ tail: 0 })
+  })
+
+  it("reads --tail as a duration, and on its own as until interrupted", () => {
+    expect(parseCliArgs(["push", "dist/main.slua", "--tail", "5s"]).command).toMatchObject({
+      tail: 5_000,
+    })
+
+    expect(parseCliArgs(["push", "dist/main.slua", "--tail", "250"]).command).toMatchObject({
+      tail: 250,
+    })
+
+    expect(parseCliArgs(["push", "--tail", "--all"]).command).toMatchObject({ tail: "forever" })
+    expect(parseCliArgs(["push", "dist/main.slua", "--tail"]).command).toMatchObject({
+      tail: "forever",
+    })
+  })
+
+  it("rejects a --tail value that is not a duration", () => {
+    expect(() => parseCliArgs(["push", "--tail", "soon", "--all"])).toThrow(CliUsageError)
   })
 
   it("allows push with only a file, leaving the target to config or a header", () => {

--- a/packages/viewer-client/src/cli/args.test.ts
+++ b/packages/viewer-client/src/cli/args.test.ts
@@ -95,8 +95,26 @@ describe("parseCliArgs", () => {
     })
   })
 
+  it("leaves the file alone when --tail comes before it", () => {
+    // parseArgs hands the file to --tail, leaving the push nothing to deploy.
+    expect(parseCliArgs(["push", "--tail", "dist/main.slua"]).command).toMatchObject({
+      name: "push",
+      file: "dist/main.slua",
+      tail: "forever",
+    })
+
+    expect(parseCliArgs(["push", "--tail", "--target", "main"]).command).toMatchObject({
+      name: "push",
+      target: "main",
+      tail: "forever",
+    })
+  })
+
   it("rejects a --tail value that is not a duration", () => {
     expect(() => parseCliArgs(["push", "--tail", "soon", "--all"])).toThrow(CliUsageError)
+
+    // The file is already given, so the value has nothing else it could be.
+    expect(() => parseCliArgs(["push", "dist/main.slua", "--tail", "soon"])).toThrow(/--tail/)
   })
 
   it("allows push with only a file, leaving the target to config or a header", () => {

--- a/packages/viewer-client/src/cli/args.test.ts
+++ b/packages/viewer-client/src/cli/args.test.ts
@@ -108,6 +108,16 @@ describe("parseCliArgs", () => {
       target: "main",
       tail: "forever",
     })
+
+    // The ref is then the first positional rather than the second.
+    expect(parseCliArgs(["push", "--tail", "dist/main.slua", "Rezzer/Main"]).command).toMatchObject(
+      {
+        name: "push",
+        file: "dist/main.slua",
+        ref: { object: { kind: "name", value: "Rezzer" }, item: "Main" },
+        tail: "forever",
+      },
+    )
   })
 
   it("rejects a --tail value that is not a duration", () => {

--- a/packages/viewer-client/src/cli/args.test.ts
+++ b/packages/viewer-client/src/cli/args.test.ts
@@ -192,6 +192,30 @@ describe("parseCliArgs", () => {
     expect(parseCliArgs(["push", "a.slua", "--wait"]).global.waitMs).toBeGreaterThan(0)
   })
 
+  it("parses the connect flags a watched session takes", () => {
+    const command = parseCliArgs(["connect", "--edge", "leading", "--debounce", "500"]).command
+
+    expect(command).toMatchObject({ name: "connect", edge: "leading", debounceMs: 500 })
+    expect(() => parseCliArgs(["connect", "--edge", "sideways"])).toThrow(CliUsageError)
+  })
+
+  it("reads --since as either a cursor or a duration", () => {
+    expect(parseCliArgs(["logs", "--since", "5m"]).command).toMatchObject({
+      name: "logs",
+      since: { ms: 300_000 },
+    })
+    expect(parseCliArgs(["logs", "--since", "42"]).command).toMatchObject({
+      name: "logs",
+      since: { cursor: 42 },
+    })
+    expect(() => parseCliArgs(["logs", "--since", "soon"])).toThrow(CliUsageError)
+  })
+
+  it("names the flag it could not read in the message", () => {
+    expect(() => parseCliArgs(["wait", "--for", "soon"])).toThrow(/--for/)
+    expect(() => parseCliArgs(["push", "a.slua", "--tail", "soon"])).toThrow(/--tail/)
+  })
+
   it("treats --json as global", () => {
     expect(parseCliArgs(["objects", "--json"]).global.json).toBe(true)
   })
@@ -217,6 +241,10 @@ describe("helpText", () => {
       "set-running",
       "logs",
       "syntax",
+      "connect",
+      "status",
+      "wait",
+      "mcp",
       "--object",
       "--item",
       "--link",
@@ -228,6 +256,15 @@ describe("helpText", () => {
       "--key",
       "--follow",
       "--targets",
+      "--tail",
+      "--no-tail",
+      "--watch",
+      "--debounce",
+      "--edge",
+      "--exec",
+      "--since",
+      "--for",
+      "--direct",
       "--wait",
       "--port",
       "--timeout",

--- a/packages/viewer-client/src/cli/args.ts
+++ b/packages/viewer-client/src/cli/args.ts
@@ -132,6 +132,10 @@ function withBareTail(argv: string[]): string[] {
 
 const DURATION = /^(\d+)(ms|s|m)?$/
 
+function isDuration(raw: string): boolean {
+  return raw === TAIL_FOREVER || DURATION.test(raw.trim())
+}
+
 /**
  * A `--since` value: a cursor, or how far back to look.
  *
@@ -273,8 +277,21 @@ export function parseCliArgs(argv: string[]): CliArgs {
         throw new CliUsageError(`--vm must be one of ${VM_VALUES.join(", ")}`)
       }
 
-      const file = rest[0] ?? values.file
       const all = values.all === true
+
+      // `push --tail main.slua` hands the file over as the tail value, and
+      // leaves the push with nothing to deploy. With no file of its own, and a
+      // value no duration could be, that token is the file.
+      const swallowed =
+        values.tail !== undefined &&
+        rest[0] === undefined &&
+        values.file === undefined &&
+        values.target === undefined &&
+        !all &&
+        !isDuration(values.tail)
+
+      const file = swallowed ? values.tail : (rest[0] ?? values.file)
+      const tail = swallowed ? TAIL_FOREVER : values.tail
 
       if (file === undefined && values.target === undefined && !all) {
         throw new CliUsageError(
@@ -300,8 +317,7 @@ export function parseCliArgs(argv: string[]): CliArgs {
           saveBack: values["save-back"],
           // Something has to drain the window the save opens, and a bare
           // `push` is the case that loses output, so it drains too.
-          tail:
-            values["no-tail"] === true ? 0 : duration(values.tail ?? String(DRAIN_MS), "--tail"),
+          tail: values["no-tail"] === true ? 0 : duration(tail ?? String(DRAIN_MS), "--tail"),
         },
       }
     }

--- a/packages/viewer-client/src/cli/args.ts
+++ b/packages/viewer-client/src/cli/args.ts
@@ -6,6 +6,8 @@ import {
   PUBLISH_WAIT_MS,
 } from "../addressing.js"
 import { DEFAULT_PORT } from "../protocol/peer.js"
+import { DEBOUNCE_MS } from "../watch.js"
+import type { Since } from "./commands/control.js"
 import type { ScriptVM, SyntaxKind } from "../protocol/types.js"
 
 export class CliUsageError extends Error {
@@ -22,6 +24,8 @@ export interface GlobalFlags {
   timeoutMs?: number
   /** How long to hold the connection open waiting for the viewer to publish. */
   waitMs?: number
+  /** Talk to the viewer itself, even with a session running for this project. */
+  direct: boolean
 }
 
 export type Command =
@@ -38,11 +42,31 @@ export type Command =
       target?: string
       all: boolean
       saveBack?: boolean
+      /**
+       * How long to keep listening for the output the push produced.
+       *
+       * Milliseconds, `"forever"` for `--tail` on its own, 0 for `--no-tail`.
+       */
+      tail: number | "forever"
     }
   | { name: "link"; target: string; object?: string; item?: string; file?: string; key?: string }
   | { name: "reset"; ref: ObjectRef }
   | { name: "set-running"; ref: ObjectRef; running: boolean }
-  | { name: "logs"; object?: string; follow: boolean; targets: boolean }
+  | { name: "logs"; object?: string; follow: boolean; targets: boolean; since?: Since }
+  | { name: "status" }
+  | { name: "mcp" }
+  | { name: "wait"; since?: Since; timeoutMs?: number }
+  | {
+      name: "connect"
+      /** One target from slua.json, rather than every one of them. */
+      target?: string
+      /** Unset means on when there are targets to watch. */
+      watch?: boolean
+      debounceMs?: number
+      edge?: "trailing" | "leading"
+      /** A build command to run alongside the session. */
+      exec?: string
+    }
   | { name: "syntax"; kind?: SyntaxKind }
 
 export interface CliArgs {
@@ -68,14 +92,94 @@ const OPTIONS = {
   key: { type: "string" },
   follow: { type: "boolean", short: "f" },
   targets: { type: "boolean" },
+  tail: { type: "string" },
+  "no-tail": { type: "boolean" },
+  watch: { type: "boolean" },
+  "no-watch": { type: "boolean" },
+  debounce: { type: "string" },
+  edge: { type: "string" },
+  exec: { type: "string" },
+  since: { type: "string" },
+  for: { type: "string" },
+  direct: { type: "boolean" },
   wait: { type: "boolean" },
   help: { type: "boolean", short: "h" },
   version: { type: "boolean", short: "v" },
 } as const
 
+/** How long a plain `push` keeps listening for the output its save produced. */
+export const DRAIN_MS = 1_500
+
+/** Stands in for a `--tail` given without a duration. */
+const TAIL_FOREVER = "forever"
+
+/**
+ * Lets `--tail` stand on its own.
+ *
+ * parseArgs has no optional-argument option, so a bare `--tail` would be
+ * rejected for the value it does not need. Rewriting it before parsing keeps
+ * "until I stop it" spellable without a second flag for it.
+ */
+function withBareTail(argv: string[]): string[] {
+  return argv.map((token, index) => {
+    if (token !== "--tail") return token
+
+    const next = argv[index + 1]
+
+    return next === undefined || next.startsWith("-") ? `--tail=${TAIL_FOREVER}` : token
+  })
+}
+
+const DURATION = /^(\d+)(ms|s|m)?$/
+
+/**
+ * A `--since` value: a cursor, or how far back to look.
+ *
+ * A bare number is a cursor, since that is what the JSON output hands back.
+ * Anything with a unit is a duration, which is the form that still means
+ * something after the session that numbered the output has gone.
+ */
+function parseSince(raw: string | undefined): Since | undefined {
+  if (raw === undefined) return undefined
+
+  const match = DURATION.exec(raw.trim())
+
+  if (!match) throw new CliUsageError(`--since takes a cursor or a duration, got "${raw}"`)
+
+  if (match[2] === undefined) return { cursor: Number(match[1]) }
+
+  const value = duration(raw)
+
+  return { ms: value === "forever" ? 0 : value }
+}
+
+/** A `--tail` value: bare milliseconds, or a `5s` / `2m` duration. */
+function duration(raw: string): number | "forever" {
+  if (raw === TAIL_FOREVER) return TAIL_FOREVER
+
+  const match = DURATION.exec(raw.trim())
+
+  if (!match) {
+    throw new CliUsageError(`--tail takes a duration like 5s or 1500, got "${raw}"`)
+  }
+
+  const value = Number(match[1])
+
+  switch (match[2]) {
+    case "s":
+      return value * 1_000
+
+    case "m":
+      return value * 60_000
+
+    default:
+      return value
+  }
+}
+
 function rawParse(argv: string[]) {
   try {
-    return parseArgs({ args: argv, options: OPTIONS, allowPositionals: true })
+    return parseArgs({ args: withBareTail(argv), options: OPTIONS, allowPositionals: true })
   } catch (error) {
     throw new CliUsageError(error instanceof Error ? error.message : String(error))
   }
@@ -133,6 +237,7 @@ export function parseCliArgs(argv: string[]): CliArgs {
     json: values.json === true,
     timeoutMs: integer(values.timeout, "timeout"),
     waitMs: values.wait === true ? PUBLISH_WAIT_MS : undefined,
+    direct: values.direct === true,
   }
 
   if (values.version === true) return { global, command: { name: "version" } }
@@ -193,6 +298,9 @@ export function parseCliArgs(argv: string[]): CliArgs {
           target: values.target,
           all,
           saveBack: values["save-back"],
+          // Something has to drain the window the save opens, and a bare
+          // `push` is the case that loses output today, so it drains too.
+          tail: values["no-tail"] === true ? 0 : duration(values.tail ?? String(DRAIN_MS)),
         },
       }
     }
@@ -241,8 +349,50 @@ export function parseCliArgs(argv: string[]): CliArgs {
           object: values.object,
           follow: values.follow === true,
           targets: values.targets === true,
+          since: parseSince(values.since),
         },
       }
+
+    case "status":
+      return { global, command: { name: "status" } }
+
+    case "mcp":
+      return { global, command: { name: "mcp" } }
+
+    case "wait": {
+      const budget = values.for === undefined ? undefined : duration(values.for)
+
+      return {
+        global,
+        command: {
+          name: "wait",
+          since: parseSince(values.since),
+          timeoutMs: budget === "forever" ? undefined : budget,
+        },
+      }
+    }
+
+    case "connect": {
+      const edge = values.edge
+
+      if (edge !== undefined && edge !== "trailing" && edge !== "leading") {
+        throw new CliUsageError("--edge must be trailing or leading")
+      }
+
+      return {
+        global,
+        command: {
+          name: "connect",
+          target: values.target,
+          // Unset rather than defaulted: whether watching makes sense depends
+          // on slua.json, which the parser does not read.
+          watch: values["no-watch"] === true ? false : values.watch === true ? true : undefined,
+          debounceMs: integer(values.debounce, "debounce"),
+          edge,
+          exec: values.exec,
+        },
+      }
+    }
 
     case "syntax": {
       const kind = rest[0]
@@ -274,6 +424,10 @@ Commands
   set-running on|off <object>/<item>
                                    Start or stop a script
   logs                             Stream runtime output from published objects
+  connect                          Hold a session: watch, push and tail in one
+  status                           What the running session is doing
+  wait                             Block until the next push settles
+  mcp                              Serve the session to an agent over MCP
   syntax [defs.lsl|defs.lua]       Dump language definitions
   help                             Show this message
 
@@ -314,6 +468,20 @@ Options
   --key <key>          Description key to pair on (default slua:<name>)
   -f, --follow         Keep streaming (logs)
   --targets            Only output from items your slua.json targets (logs)
+  --tail [duration]    Keep listening after a push, e.g. 5s; on its own,
+                       until interrupted (default ${DRAIN_MS}ms)
+  --no-tail            Push without waiting for output (push)
+  --watch/--no-watch   Push when a target's output changes (connect, on by
+                       default when slua.json has targets)
+  --debounce <ms>      How long a target must be quiet before it is pushed
+                       (connect, default ${DEBOUNCE_MS}ms)
+  --edge <edge>        Which end of that window to push on: trailing or
+                       leading (connect, default trailing)
+  --exec <command>     Run a build alongside the session (connect)
+  --since <cursor|duration>
+                       Output after a cursor, or from the last 5m (logs, wait)
+  --for <duration>     How long to block (wait, default 30s)
+  --direct             Talk to the viewer even when a session is running
   --wait               Wait for the viewer to publish, so "Explore in IDE"
                        has a client to publish to
   --port <port>        Viewer websocket port (default ${DEFAULT_PORT})
@@ -329,7 +497,13 @@ Examples
   slua-viewer push dist/main.slua --wait
   slua-viewer link main
   slua-viewer push --all
+  slua-viewer push --all --tail 10s
   slua-viewer logs --object 4f2b... --follow
   slua-viewer logs --targets --follow
+  slua-viewer connect
+  slua-viewer connect --exec "tstl -p tsconfig.json --watch"
+  slua-viewer status --json
+  slua-viewer wait --since 412 --for 20s
+  slua-viewer logs --since 5m
 `
 }

--- a/packages/viewer-client/src/cli/args.ts
+++ b/packages/viewer-client/src/cli/args.ts
@@ -116,9 +116,9 @@ const TAIL_FOREVER = "forever"
 /**
  * Lets `--tail` stand on its own.
  *
- * parseArgs has no optional-argument option, so a bare `--tail` would be
- * rejected for the value it does not need. Rewriting it before parsing keeps
- * "until I stop it" spellable without a second flag for it.
+ * parseArgs has no optional-argument option, so a bare `--tail` is rejected
+ * for the value it does not need. Rewriting it before parsing keeps "until I
+ * stop it" spellable without a second flag.
  */
 function withBareTail(argv: string[]): string[] {
   return argv.map((token, index) => {
@@ -148,19 +148,19 @@ function parseSince(raw: string | undefined): Since | undefined {
 
   if (match[2] === undefined) return { cursor: Number(match[1]) }
 
-  const value = duration(raw)
+  const value = duration(raw, "--since")
 
   return { ms: value === "forever" ? 0 : value }
 }
 
-/** A `--tail` value: bare milliseconds, or a `5s` / `2m` duration. */
-function duration(raw: string): number | "forever" {
+/** Bare milliseconds, or a `5s` / `2m` duration. */
+function duration(raw: string, flag: string): number | "forever" {
   if (raw === TAIL_FOREVER) return TAIL_FOREVER
 
   const match = DURATION.exec(raw.trim())
 
   if (!match) {
-    throw new CliUsageError(`--tail takes a duration like 5s or 1500, got "${raw}"`)
+    throw new CliUsageError(`${flag} takes a duration like 5s or 1500, got "${raw}"`)
   }
 
   const value = Number(match[1])
@@ -299,8 +299,9 @@ export function parseCliArgs(argv: string[]): CliArgs {
           all,
           saveBack: values["save-back"],
           // Something has to drain the window the save opens, and a bare
-          // `push` is the case that loses output today, so it drains too.
-          tail: values["no-tail"] === true ? 0 : duration(values.tail ?? String(DRAIN_MS)),
+          // `push` is the case that loses output, so it drains too.
+          tail:
+            values["no-tail"] === true ? 0 : duration(values.tail ?? String(DRAIN_MS), "--tail"),
         },
       }
     }
@@ -360,7 +361,7 @@ export function parseCliArgs(argv: string[]): CliArgs {
       return { global, command: { name: "mcp" } }
 
     case "wait": {
-      const budget = values.for === undefined ? undefined : duration(values.for)
+      const budget = values.for === undefined ? undefined : duration(values.for, "--for")
 
       return {
         global,
@@ -384,7 +385,7 @@ export function parseCliArgs(argv: string[]): CliArgs {
         command: {
           name: "connect",
           target: values.target,
-          // Unset rather than defaulted: whether watching makes sense depends
+          // Unset rather than defaulted. Whether watching makes sense depends
           // on slua.json, which the parser does not read.
           watch: values["no-watch"] === true ? false : values.watch === true ? true : undefined,
           debounceMs: integer(values.debounce, "debounce"),
@@ -480,7 +481,8 @@ Options
   --exec <command>     Run a build alongside the session (connect)
   --since <cursor|duration>
                        Output after a cursor, or from the last 5m (logs, wait)
-  --for <duration>     How long to block (wait, default 30s)
+  --for <duration>     How long to block (wait, default 30s); "forever" is
+                       accepted but the session still caps the wait at 30s
   --direct             Talk to the viewer even when a session is running
   --wait               Wait for the viewer to publish, so "Explore in IDE"
                        has a client to publish to

--- a/packages/viewer-client/src/cli/args.ts
+++ b/packages/viewer-client/src/cli/args.ts
@@ -183,7 +183,24 @@ function duration(raw: string, flag: string): number | "forever" {
 
 function rawParse(argv: string[]) {
   try {
-    return parseArgs({ args: withBareTail(argv), options: OPTIONS, allowPositionals: true })
+    const { values, positionals, tokens } = parseArgs({
+      args: withBareTail(argv),
+      options: OPTIONS,
+      allowPositionals: true,
+      tokens: true,
+    })
+
+    const tail = tokens.find((token) => token.kind === "option" && token.name === "tail")
+
+    // The command itself is the first positional, so the second is the first
+    // one the command was given.
+    const first = tokens.filter((token) => token.kind === "positional")[1]
+
+    // `push --tail main.slua` and `push main.slua --tail soon` are one shape to
+    // parseArgs, and only the order says which token --tail was reaching for.
+    const tailLeads = tail !== undefined && (first === undefined || first.index > tail.index)
+
+    return { values, positionals, tailLeads }
   } catch (error) {
     throw new CliUsageError(error instanceof Error ? error.message : String(error))
   }
@@ -234,7 +251,7 @@ function targetRef(
 }
 
 export function parseCliArgs(argv: string[]): CliArgs {
-  const { values, positionals } = rawParse(argv)
+  const { values, positionals, tailLeads } = rawParse(argv)
 
   const global: GlobalFlags = {
     port: integer(values.port, "port") ?? DEFAULT_PORT,
@@ -280,11 +297,11 @@ export function parseCliArgs(argv: string[]): CliArgs {
       const all = values.all === true
 
       // `push --tail main.slua` hands the file over as the tail value, and
-      // leaves the push with nothing to deploy. With no file of its own, and a
-      // value no duration could be, that token is the file.
+      // leaves the push with nothing to deploy. A value no duration could be,
+      // where the flag came first and no file did, is the file.
       const swallowed =
         values.tail !== undefined &&
-        rest[0] === undefined &&
+        tailLeads &&
         values.file === undefined &&
         values.target === undefined &&
         !all &&
@@ -310,7 +327,9 @@ export function parseCliArgs(argv: string[]): CliArgs {
         command: {
           name: "push",
           file,
-          ref: optionalTargetRef(rest[1], values),
+          // One position earlier when --tail took the file, since the ref is
+          // then the first positional rather than the second.
+          ref: optionalTargetRef(swallowed ? rest[0] : rest[1], values),
           vm: values.vm as ScriptVM | undefined,
           target: values.target,
           all,

--- a/packages/viewer-client/src/cli/commands/connect.ts
+++ b/packages/viewer-client/src/cli/commands/connect.ts
@@ -296,6 +296,9 @@ export async function connectCommand(
   let pushing = false
   let lastRun: PushRun | undefined
 
+  /** Targets saved while the viewer was away, owed to the next connection. */
+  const pending = new Set<string>()
+
   /** Recent output, for a client that attached after it was printed. */
   const buffer: Record<string, unknown>[] = []
   const outcomes = new Map<string, Record<string, unknown>>()
@@ -342,11 +345,23 @@ export async function connectCommand(
 
     pushing = true
 
+    // Nothing settles on a run with no viewer behind it. The watcher has
+    // already recorded the content as pushed, so these targets are held for
+    // the reconnect, and a client waiting reads an empty run as a clean push.
+    const reached = client !== undefined
+
+    if (!reached) {
+      for (const target of changed) pending.add(target.name)
+
+      reporter.note(pc.yellow("not connected; the change will be pushed on reconnect"))
+    }
+
     try {
-      await pushEach(changed, run)
+      if (reached) await pushEach(changed, run)
     } finally {
       pushing = false
-      lastRun = run
+
+      if (reached) lastRun = run
 
       // Reloaded after every push: the build that prompted it rewrote the
       // source maps, and this run's output through the last build's maps
@@ -355,7 +370,7 @@ export async function connectCommand(
 
       // Snapshotted, since settling removes the waiter from the set it is
       // being iterated out of.
-      const waiting = [...waiters]
+      const waiting = reached ? [...waiters] : []
 
       for (const waiter of waiting) {
         if (run.cursor > waiter.since) {
@@ -367,11 +382,7 @@ export async function connectCommand(
   }
 
   const pushEach = async (changed: readonly Target[], run: PushRun) => {
-    if (!client) {
-      reporter.note(pc.yellow("not connected; the change will be pushed on reconnect"))
-
-      return
-    }
+    if (!client) return
 
     for (const target of changed) {
       const result = await pushTarget(client, target, reporter, changed.length > 1, {
@@ -602,6 +613,18 @@ export async function connectCommand(
       // Re-published on every reconnect: a viewer that restarted has
       // forgotten everything the old connection published.
       await publishTargets(connected, targets, reporter, publish)
+
+      // After publishing, since a push to an unpublished object is the error
+      // publishing is there to avoid.
+      if (pending.size > 0) {
+        const owed = [...pending]
+
+        pending.clear()
+
+        reporter.note(pc.dim(`pushing ${owed.join(", ")}, saved while disconnected`))
+
+        void watcher?.trigger(owed)
+      }
     },
     onStop: async () => {
       // Awaited: a push in flight owns the connection this teardown is about

--- a/packages/viewer-client/src/cli/commands/connect.ts
+++ b/packages/viewer-client/src/cli/commands/connect.ts
@@ -9,7 +9,11 @@ import {
   withoutWait,
 } from "../../addressing.js"
 import { ViewerClient } from "../../client.js"
-import { startControlServer, type ControlServer } from "../../control/server.js"
+import {
+  SessionAlreadyRunningError,
+  startControlServer,
+  type ControlServer,
+} from "../../control/server.js"
 import { ConnectionClosedError } from "../../protocol/errors.js"
 import { controlPath } from "../../control/socket.js"
 import { SAVE_TIMEOUT_MS } from "../../protocol/peer.js"
@@ -34,9 +38,9 @@ import { collectTargets, pushTarget } from "./push.js"
 /**
  * Runs the build in a child process, prefixed, so this is one terminal.
  *
- * The compiler stays the scaffold's business: tstl's incremental watch is
- * better than anything here, and the multi template's build script means
- * there is no single invocation to assume. This just carries its output.
+ * The compiler stays the scaffold's business. tstl's incremental watch beats
+ * anything here, and the multi template's build script means there is no
+ * single invocation to assume. This only carries the output.
  */
 function runBuild(exec: string, reporter: Reporter): () => void {
   reporter.note(pc.dim(`build ${exec}`))
@@ -67,7 +71,7 @@ function runBuild(exec: string, reporter: Reporter): () => void {
       // Negative pid is the group, which is the point of detaching it.
       process.kill(-child.pid)
     } catch {
-      // Already gone, which is the outcome we wanted anyway.
+      // Already gone, which is the outcome we wanted.
     }
   }
 }
@@ -75,10 +79,10 @@ function runBuild(exec: string, reporter: Reporter): () => void {
 /**
  * Publishes the objects the targets deploy to.
  *
- * Runtime output is only forwarded for published objects, so a session that
- * skipped this would connect, watch, push and then sit in silence. Failing to
- * publish one object is reported rather than fatal: the object may simply not
- * be rezzed yet, and the next push will ask for it again.
+ * Runtime output only reaches us for published objects, so a session that
+ * skipped this would connect, watch, push and sit in silence. One object
+ * failing is reported rather than fatal, since it may not be rezzed yet and
+ * the next push asks again.
  */
 async function publishTargets(
   client: ViewerClient,
@@ -150,8 +154,8 @@ const NO_VIEWER =
  * How long `control.wait` keeps listening after the push it was waiting for.
  *
  * A save settles the moment the viewer answers, but the script it restarted
- * says its first words a beat later, and "results plus output" with no output
- * in it is the answer an agent would then have to poll for anyway.
+ * speaks a beat later, and results with no output in them leave an agent
+ * polling for the rest.
  */
 const SETTLE_DRAIN_MS = 1_500
 
@@ -171,7 +175,7 @@ interface Waiter {
  * Consecutive identical lines, as one record with a count.
  *
  * A script looping on `llOwnerSay` outruns any reader, and a thousand copies
- * of one line is not a thousand times as informative.
+ * of one line say no more than one.
  */
 function collapse(records: Record<string, unknown>[]): Record<string, unknown>[] {
   const out: Record<string, unknown>[] = []
@@ -200,15 +204,14 @@ function collapse(records: Record<string, unknown>[]): Record<string, unknown>[]
  * Waits for the build to catch up with the source, before an explicit push.
  *
  * The session does not own the compiler, so "push now" means "push what is on
- * disk now". A human typing `push` has already watched their build run; an
- * agent that edits a file and asks for a push in the same breath has not, and
- * would deploy the build from before its own edit, then read the output as
- * though it were the new one.
+ * disk now". A human typing `push` has watched their build run. An agent that
+ * edits a file and asks for a push in the same breath has not, and would
+ * deploy the build from before its own edit, then read the output as the new
+ * one.
  *
- * The source map names the inputs, so a source newer than the output is a
- * build still owed. A build that never arrives, because it is broken or
- * because there is no build at all, must not hang the push, so this gives up
- * and says so rather than waiting forever.
+ * The source map names the inputs, so a source newer than the output means a
+ * build is still owed. One that never arrives, broken or absent, gives up here
+ * rather than hanging the push.
  */
 async function awaitBuild(targets: readonly Target[], reporter: Reporter): Promise<number> {
   const started = Date.now()
@@ -270,7 +273,7 @@ export async function connectCommand(
 
   // A freshly scaffolded project has no slua.json until `link` writes one, and
   // `dev` is the first thing anyone runs, so a session with nothing to watch
-  // still holds the connection and streams output rather than refusing.
+  // still holds the connection and streams output.
   const targets = config
     ? await collectTargets(
         { name: "push", all: command.target === undefined, target: command.target, tail: 0 },
@@ -283,9 +286,8 @@ export async function connectCommand(
   // Source maps, so runtime output arrives already mapped back to TypeScript.
   let view = await loadTargets()
 
-  // Watching is a behaviour of the session, not the other way round: a session
-  // with it off still holds the connection and captures output, which is what
-  // an agent driving pushes explicitly wants.
+  // A session with watching off still holds the connection and captures
+  // output, which is what an agent driving its own pushes wants.
   const watching = command.watch ?? targets.length > 0
 
   let client: ViewerClient | undefined
@@ -302,7 +304,7 @@ export async function connectCommand(
   const remember = (payload: Record<string, unknown>) => {
     buffer.push(payload)
 
-    // Bounded: the file sink is the complete record, this is only what a
+    // Bounded. The file sink holds the complete record; this is only what a
     // client can still ask for after the fact.
     if (buffer.length > BUFFER_RECORDS) buffer.splice(0, buffer.length - BUFFER_RECORDS)
   }
@@ -323,7 +325,7 @@ export async function connectCommand(
     return { logs, truncated: matching.length - logs.length }
   }
 
-  // Written before anything can be logged, so a session that dies in its first
+  // Opened before anything can be logged, so a session that dies in its first
   // second still leaves the reason behind.
   const state: SessionState = await openState(
     root,
@@ -346,10 +348,9 @@ export async function connectCommand(
       pushing = false
       lastRun = run
 
-      // Reloaded after every push, because the build that prompted it rewrote
-      // the source maps. Mapping this run's output through the last build's
-      // maps quietly points at whatever used to be on those lines, which is
-      // worse than not mapping at all.
+      // Reloaded after every push: the build that prompted it rewrote the
+      // source maps, and this run's output through the last build's maps
+      // points at whatever used to be on those lines.
       view = await loadTargets()
 
       // Snapshotted, since settling removes the waiter from the set it is
@@ -375,7 +376,7 @@ export async function connectCommand(
     for (const target of changed) {
       const result = await pushTarget(client, target, reporter, changed.length > 1, {
         // A watch event is not the moment to sit on the publish button for
-        // five minutes; the session already asked for that at startup.
+        // five minutes. The session already asked for that at startup.
         ...withoutWait(publish),
       })
 
@@ -384,9 +385,8 @@ export async function connectCommand(
       run.targets.push(result.payload)
 
       // A save can succeed while the compile fails, and the source is stored
-      // either way, so the item now holds code that never ran. A human who
-      // typed `push` reads the error; three edits later nobody does, so say
-      // plainly what is actually running out there.
+      // either way, so the item now holds code that never ran. Three edits
+      // later nobody is reading the error, so say what is actually running.
       if (result.payload.compiled === false && result.payload.ok !== undefined) {
         reporter.note(
           pc.yellow(
@@ -400,7 +400,7 @@ export async function connectCommand(
   const stopBuild = command.exec ? runBuild(command.exec, reporter) : undefined
 
   watcher = watchTargets(targets, push, {
-    // Always built, watching or not: it owns the queue that keeps two saves
+    // Always built, watching or not. It owns the queue that keeps two saves
     // from racing against one prim, and `control.push` goes through it too.
     enabled: watching,
     debounceMs: command.debounceMs,
@@ -553,6 +553,11 @@ export async function connectCommand(
 
     reporter.note(pc.dim(`control socket at ${control.path}`))
   } catch (error) {
+    // Two sessions on one project would push the same targets twice and
+    // restart the same script twice, so this one is a stop rather than a
+    // downgrade.
+    if (error instanceof SessionAlreadyRunningError) throw error
+
     // A session without a socket is still a session: it watches, pushes and
     // logs. Only the calls an agent would make are missing, so say so and
     // carry on.
@@ -562,7 +567,7 @@ export async function connectCommand(
   }
 
   await runSession({
-    // A session is a session: it outlives a viewer restart by definition.
+    // A session outlives a viewer restart by definition.
     follow: true,
     reporter,
     connect: () => ViewerClient.connect({ port: global.port, timeoutMs: global.timeoutMs }),
@@ -599,7 +604,10 @@ export async function connectCommand(
       await publishTargets(connected, targets, reporter, publish)
     },
     onStop: async () => {
-      watcher?.close()
+      // Awaited: a push in flight owns the connection this teardown is about
+      // to close, and its result still has to reach the log.
+      await watcher?.close()
+
       stopBuild?.()
 
       // Waiters first: a client blocked on `wait` should be told the session

--- a/packages/viewer-client/src/cli/commands/connect.ts
+++ b/packages/viewer-client/src/cli/commands/connect.ts
@@ -1,0 +1,620 @@
+import { spawn } from "node:child_process"
+import { stat } from "node:fs/promises"
+import pc from "picocolors"
+import {
+  ensurePublished,
+  formatObjectSelector,
+  PUBLISH_HINT,
+  type PublishOptions,
+  withoutWait,
+} from "../../addressing.js"
+import { ViewerClient } from "../../client.js"
+import { startControlServer, type ControlServer } from "../../control/server.js"
+import { ConnectionClosedError } from "../../protocol/errors.js"
+import { controlPath } from "../../control/socket.js"
+import { SAVE_TIMEOUT_MS } from "../../protocol/peer.js"
+import type { RuntimeDebug, RuntimeError } from "../../protocol/types.js"
+import { openState, type SessionState } from "../../state.js"
+import { loadSourceMapFor } from "../../sourcemap.js"
+import { loadConfig, type Target } from "../../targets.js"
+import { watchTargets, type Watcher } from "../../watch.js"
+import type { Command, GlobalFlags } from "../args.js"
+import { displayPath, type Reporter } from "../output.js"
+import {
+  cursor,
+  loadTargets,
+  nextCursor,
+  recordPayload,
+  toRecord,
+  writeRecord,
+} from "../runtime-view.js"
+import { runSession } from "../session.js"
+import { collectTargets, pushTarget } from "./push.js"
+
+/**
+ * Runs the build in a child process, prefixed, so this is one terminal.
+ *
+ * The compiler stays the scaffold's business: tstl's incremental watch is
+ * better than anything here, and the multi template's build script means
+ * there is no single invocation to assume. This just carries its output.
+ */
+function runBuild(exec: string, reporter: Reporter): () => void {
+  reporter.note(pc.dim(`build ${exec}`))
+
+  // Its own process group, so stopping the session stops the whole build
+  // pipeline rather than orphaning whatever the shell started.
+  const child = spawn(exec, { shell: true, detached: true, stdio: ["ignore", "pipe", "pipe"] })
+
+  const forward = (chunk: Buffer) => {
+    for (const line of chunk.toString().split("\n")) {
+      if (line.trim() !== "") reporter.note(`${pc.dim("build")} ${line}`)
+    }
+  }
+
+  child.stdout?.on("data", forward)
+  child.stderr?.on("data", forward)
+
+  child.on("error", (error) => reporter.error(`build failed to start: ${error.message}`))
+
+  child.on("exit", (code) => {
+    if (code !== 0 && code !== null) reporter.note(pc.yellow(`build exited with ${code}`))
+  })
+
+  return () => {
+    if (child.pid === undefined || child.exitCode !== null) return
+
+    try {
+      // Negative pid is the group, which is the point of detaching it.
+      process.kill(-child.pid)
+    } catch {
+      // Already gone, which is the outcome we wanted anyway.
+    }
+  }
+}
+
+/**
+ * Publishes the objects the targets deploy to.
+ *
+ * Runtime output is only forwarded for published objects, so a session that
+ * skipped this would connect, watch, push and then sit in silence. Failing to
+ * publish one object is reported rather than fatal: the object may simply not
+ * be rezzed yet, and the next push will ask for it again.
+ */
+async function publishTargets(
+  client: ViewerClient,
+  targets: readonly Target[],
+  reporter: Reporter,
+  publish: PublishOptions,
+): Promise<void> {
+  const seen = new Set<string>()
+
+  let first = true
+
+  for (const target of targets) {
+    const key = formatObjectSelector(target.ref.object)
+
+    if (seen.has(key)) continue
+
+    seen.add(key)
+
+    try {
+      // Only the first object waits on the publish button. Waiting five
+      // minutes per target would make a mistyped selector look like a hang.
+      const object = await ensurePublished(
+        client,
+        target.ref.object,
+        first ? publish : withoutWait(publish),
+      )
+
+      first = false
+
+      reporter.note(pc.dim(`watching ${object.objectName} (${object.objectId})`))
+    } catch (error) {
+      reporter.note(
+        pc.yellow(
+          `${target.name}: ${error instanceof Error ? error.message : String(error)}; pushing will try again`,
+        ),
+      )
+    }
+  }
+}
+
+/** Viewer notifications an attached client is entitled to see. */
+const BROADCAST = [
+  "runtime.debug",
+  "runtime.error",
+  "object.publish",
+  "object.unpublish",
+  "object.update",
+  "script.compiled",
+  "script.unsubscribe",
+  "language.syntax.change",
+] as const
+
+/** How many records one `control.logs` or `control.wait` answer may carry. */
+const MAX_RECORDS = 200
+
+/** How many records the session keeps in memory for those answers. */
+const BUFFER_RECORDS = 2_000
+
+const DEFAULT_WAIT_MS = 30_000
+
+/** How long an explicit push waits for a build that has not run yet. */
+const BUILD_WAIT_MS = 10_000
+
+/** Said to a control client when the viewer is the thing that went away. */
+const NO_VIEWER =
+  "the session lost its viewer connection and is reconnecting; is the viewer running?"
+
+/**
+ * How long `control.wait` keeps listening after the push it was waiting for.
+ *
+ * A save settles the moment the viewer answers, but the script it restarted
+ * says its first words a beat later, and "results plus output" with no output
+ * in it is the answer an agent would then have to poll for anyway.
+ */
+const SETTLE_DRAIN_MS = 1_500
+
+interface PushRun {
+  /** This push's own place in the cursor sequence, taken before it started. */
+  cursor: number
+  at: string
+  targets: Record<string, unknown>[]
+}
+
+interface Waiter {
+  since: number
+  settle: (run: PushRun | undefined) => void
+}
+
+/**
+ * Consecutive identical lines, as one record with a count.
+ *
+ * A script looping on `llOwnerSay` outruns any reader, and a thousand copies
+ * of one line is not a thousand times as informative.
+ */
+function collapse(records: Record<string, unknown>[]): Record<string, unknown>[] {
+  const out: Record<string, unknown>[] = []
+
+  for (const record of records) {
+    const previous = out.at(-1)
+
+    if (
+      previous &&
+      previous.level === record.level &&
+      previous.message === record.message &&
+      previous.objectId === record.objectId
+    ) {
+      previous.repeat = ((previous.repeat as number | undefined) ?? 1) + 1
+
+      continue
+    }
+
+    out.push({ ...record })
+  }
+
+  return out
+}
+
+/**
+ * Waits for the build to catch up with the source, before an explicit push.
+ *
+ * The session does not own the compiler, so "push now" means "push what is on
+ * disk now". A human typing `push` has already watched their build run; an
+ * agent that edits a file and asks for a push in the same breath has not, and
+ * would deploy the build from before its own edit, then read the output as
+ * though it were the new one.
+ *
+ * The source map names the inputs, so a source newer than the output is a
+ * build still owed. A build that never arrives, because it is broken or
+ * because there is no build at all, must not hang the push, so this gives up
+ * and says so rather than waiting forever.
+ */
+async function awaitBuild(targets: readonly Target[], reporter: Reporter): Promise<number> {
+  const started = Date.now()
+  const pending: { file: string; at: number }[] = []
+
+  for (const target of targets) {
+    const output = await stat(target.file).catch(() => undefined)
+
+    if (!output) continue
+
+    const map = await loadSourceMapFor(target.file)
+
+    if (!map) continue
+
+    let newest = 0
+
+    for (const source of map.sources) {
+      const input = await stat(source).catch(() => undefined)
+
+      if (input) newest = Math.max(newest, input.mtimeMs)
+    }
+
+    if (newest > output.mtimeMs) pending.push({ file: target.file, at: output.mtimeMs })
+  }
+
+  if (pending.length === 0) return 0
+
+  reporter.note(pc.dim("waiting for the build to catch up with the source"))
+
+  while (Date.now() - started < BUILD_WAIT_MS) {
+    await new Promise((sleep) => setTimeout(sleep, 100))
+
+    const stale = []
+
+    for (const entry of pending) {
+      const output = await stat(entry.file).catch(() => undefined)
+
+      if (!output || output.mtimeMs <= entry.at) stale.push(entry)
+    }
+
+    if (stale.length === 0) return Date.now() - started
+
+    pending.length = 0
+    pending.push(...stale)
+  }
+
+  reporter.note(pc.yellow("the build has not produced new output; pushing what is on disk"))
+
+  return Date.now() - started
+}
+
+export async function connectCommand(
+  global: GlobalFlags,
+  command: Extract<Command, { name: "connect" }>,
+  reporter: Reporter,
+  publish: PublishOptions = {},
+): Promise<number> {
+  const config = await loadConfig()
+
+  // A freshly scaffolded project has no slua.json until `link` writes one, and
+  // `dev` is the first thing anyone runs, so a session with nothing to watch
+  // still holds the connection and streams output rather than refusing.
+  const targets = config
+    ? await collectTargets(
+        { name: "push", all: command.target === undefined, target: command.target, tail: 0 },
+        config,
+      )
+    : []
+
+  const root = config?.root ?? process.cwd()
+
+  // Source maps, so runtime output arrives already mapped back to TypeScript.
+  let view = await loadTargets()
+
+  // Watching is a behaviour of the session, not the other way round: a session
+  // with it off still holds the connection and captures output, which is what
+  // an agent driving pushes explicitly wants.
+  const watching = command.watch ?? targets.length > 0
+
+  let client: ViewerClient | undefined
+  let watcher: Watcher | undefined
+  let control: ControlServer | undefined
+  let pushing = false
+  let lastRun: PushRun | undefined
+
+  /** Recent output, for a client that attached after it was printed. */
+  const buffer: Record<string, unknown>[] = []
+  const outcomes = new Map<string, Record<string, unknown>>()
+  const waiters = new Set<Waiter>()
+
+  const remember = (payload: Record<string, unknown>) => {
+    buffer.push(payload)
+
+    // Bounded: the file sink is the complete record, this is only what a
+    // client can still ask for after the fact.
+    if (buffer.length > BUFFER_RECORDS) buffer.splice(0, buffer.length - BUFFER_RECORDS)
+  }
+
+  /** Records after a cursor or a moment, collapsed and capped, never dropped. */
+  const since = (from: number, limit = MAX_RECORDS, sinceMs?: number) => {
+    const cutoff = sinceMs === undefined ? undefined : Date.now() - sinceMs
+
+    const matching = collapse(
+      buffer.filter((entry) => {
+        if (cutoff !== undefined) return new Date(String(entry.time)).getTime() >= cutoff
+
+        return (entry.seq as number) > from
+      }),
+    )
+    const logs = matching.slice(-limit)
+
+    return { logs, truncated: matching.length - logs.length }
+  }
+
+  // Written before anything can be logged, so a session that dies in its first
+  // second still leaves the reason behind.
+  const state: SessionState = await openState(
+    root,
+    { port: global.port, root, socket: controlPath(root) },
+    { onError: (error) => reporter.note(pc.yellow(`log sink: ${error.message}`)) },
+  )
+
+  reporter.note(pc.dim(`session state in ${displayPath(state.directory)}`))
+
+  const push = async (changed: readonly Target[]) => {
+    // Its own place in the sequence, taken before anything is saved, so
+    // "settled since this cursor" can never match the run before it.
+    const run: PushRun = { cursor: nextCursor(), at: new Date().toISOString(), targets: [] }
+
+    pushing = true
+
+    try {
+      await pushEach(changed, run)
+    } finally {
+      pushing = false
+      lastRun = run
+
+      // Reloaded after every push, because the build that prompted it rewrote
+      // the source maps. Mapping this run's output through the last build's
+      // maps quietly points at whatever used to be on those lines, which is
+      // worse than not mapping at all.
+      view = await loadTargets()
+
+      // Snapshotted, since settling removes the waiter from the set it is
+      // being iterated out of.
+      const waiting = [...waiters]
+
+      for (const waiter of waiting) {
+        if (run.cursor > waiter.since) {
+          waiters.delete(waiter)
+          waiter.settle(run)
+        }
+      }
+    }
+  }
+
+  const pushEach = async (changed: readonly Target[], run: PushRun) => {
+    if (!client) {
+      reporter.note(pc.yellow("not connected; the change will be pushed on reconnect"))
+
+      return
+    }
+
+    for (const target of changed) {
+      const result = await pushTarget(client, target, reporter, changed.length > 1, {
+        // A watch event is not the moment to sit on the publish button for
+        // five minutes; the session already asked for that at startup.
+        ...withoutWait(publish),
+      })
+
+      state.append({ kind: "push", time: run.at, ...result.payload })
+      outcomes.set(target.name, result.payload)
+      run.targets.push(result.payload)
+
+      // A save can succeed while the compile fails, and the source is stored
+      // either way, so the item now holds code that never ran. A human who
+      // typed `push` reads the error; three edits later nobody does, so say
+      // plainly what is actually running out there.
+      if (result.payload.compiled === false && result.payload.ok !== undefined) {
+        reporter.note(
+          pc.yellow(
+            `${target.name}: the running script is unchanged, the item now holds source that did not compile`,
+          ),
+        )
+      }
+    }
+  }
+
+  const stopBuild = command.exec ? runBuild(command.exec, reporter) : undefined
+
+  watcher = watchTargets(targets, push, {
+    // Always built, watching or not: it owns the queue that keeps two saves
+    // from racing against one prim, and `control.push` goes through it too.
+    enabled: watching,
+    debounceMs: command.debounceMs,
+    edge: command.edge,
+    onDefer: (deferred, waitMs) =>
+      reporter.note(
+        pc.dim(
+          `holding ${deferred.map((target) => target.name).join(", ")} for ${Math.round(waitMs / 1000)}s, pushes are expensive`,
+        ),
+      ),
+    onError: (error) => reporter.error(error.message),
+  })
+
+  if (watching) {
+    reporter.note(
+      pc.dim(
+        `watching ${targets.map((target) => displayPath(target.file)).join(", ")} for changes`,
+      ),
+    )
+  } else if (targets.length === 0) {
+    reporter.note(
+      pc.yellow(
+        `nothing to watch yet. pair an object with "slua-viewer link <name>", then ${PUBLISH_HINT}`,
+      ),
+    )
+  } else {
+    reporter.note(pc.dim("watching off; holding the connection and streaming output"))
+  }
+
+  try {
+    control = await startControlServer(root, {
+      handshake: () => client?.connection.handshake,
+
+      status: () => ({
+        connected: client !== undefined,
+        watching,
+        pushing,
+        cursor: cursor(),
+        viewer: { port: global.port, name: client?.connection.handshake?.viewerName },
+        logPath: state.logPath,
+        targets: targets.map((target) => ({
+          name: target.name,
+          file: target.file,
+          item: target.ref.item,
+          lastPush: outcomes.get(target.name),
+        })),
+      }),
+
+      logs: ({ since: from = 0, limit, sinceMs }) => ({
+        cursor: cursor(),
+        logPath: state.logPath,
+        ...since(from, limit ?? MAX_RECORDS, sinceMs),
+      }),
+
+      push: async ({ targets: names }) => {
+        // The cursor from before the push, so handing it straight to `wait`
+        // cannot match the run before this one.
+        const from = cursor()
+
+        const wanted = names?.length
+          ? targets.filter((target) => names.includes(target.name))
+          : targets
+
+        // Before the trigger rather than inside it, so the watcher records the
+        // content the build produced and does not push it a second time.
+        const waited = await awaitBuild(wanted, reporter)
+
+        // Not awaited: `wait` is what blocks, and a client that wants the
+        // results asks for them with the cursor this hands back.
+        void watcher?.trigger(names)
+
+        return {
+          cursor: from,
+          waited,
+          targets: wanted.map((target) => target.name),
+        }
+      },
+
+      wait: ({ since: from = 0, timeoutMs = DEFAULT_WAIT_MS }) =>
+        new Promise((settled) => {
+          const deadline = Date.now() + timeoutMs
+
+          const answer = (run: PushRun | undefined) => ({
+            settled: run !== undefined,
+            cursor: cursor(),
+            targets: run?.targets ?? [],
+            logPath: state.logPath,
+            ...since(from),
+          })
+
+          // The push has landed, but the script it restarted has not spoken
+          // yet, so the answer waits out the same window a `push` does.
+          const drain = (run: PushRun) =>
+            setTimeout(
+              () => settled(answer(run)),
+              Math.max(0, Math.min(SETTLE_DRAIN_MS, deadline - Date.now())),
+            )
+
+          // A push newer than the caller's cursor has already settled, so
+          // there is nothing to wait for beyond its output.
+          if (lastRun && lastRun.cursor > from) {
+            drain(lastRun)
+
+            return
+          }
+
+          const waiter: Waiter = {
+            since: from,
+            settle: (run) => {
+              clearTimeout(timer)
+
+              // No run means the session is stopping, so there is nothing
+              // left to drain for.
+              if (run) drain(run)
+              else settled(answer(undefined))
+            },
+          }
+
+          const timer = setTimeout(() => {
+            waiters.delete(waiter)
+
+            // Reported as unsettled rather than as the previous run's results,
+            // which would look authoritative and be wrong.
+            settled(answer(undefined))
+          }, timeoutMs)
+
+          waiters.add(waiter)
+        }),
+
+      forward: async (method, params) => {
+        if (!client) throw new Error(NO_VIEWER)
+
+        try {
+          // A save waits on an asset upload, which no default timeout covers.
+          return await client.connection.peer.call(
+            method,
+            params,
+            method === "object.content.save" ? SAVE_TIMEOUT_MS : undefined,
+          )
+        } catch (error) {
+          // An error's type does not survive the hop to a control client: it
+          // arrives as a plain RPC failure, so whatever the type would have
+          // explained has to be in the message instead.
+          if (error instanceof ConnectionClosedError) throw new Error(NO_VIEWER, { cause: error })
+
+          throw error
+        }
+      },
+    })
+
+    reporter.note(pc.dim(`control socket at ${control.path}`))
+  } catch (error) {
+    // A session without a socket is still a session: it watches, pushes and
+    // logs. Only the calls an agent would make are missing, so say so and
+    // carry on.
+    reporter.note(
+      pc.yellow(`control socket unavailable: ${error instanceof Error ? error.message : error}`),
+    )
+  }
+
+  await runSession({
+    // A session is a session: it outlives a viewer restart by definition.
+    follow: true,
+    reporter,
+    connect: () => ViewerClient.connect({ port: global.port, timeoutMs: global.timeoutMs }),
+    onConnected: async (connected) => {
+      client = connected
+
+      // Subscribed before publishing, so output produced while the viewer is
+      // still publishing reaches the stream.
+      const record = (level: "debug" | "error", params: RuntimeDebug | RuntimeError) => {
+        const entry = toRecord(level, params, view.maps)
+
+        const payload = recordPayload(entry)
+
+        writeRecord(reporter, entry)
+        state.append({ kind: "runtime", ...payload })
+        remember(payload)
+      }
+
+      connected.on("runtime.debug", (params) => record("debug", params))
+      connected.on("runtime.error", (params) => record("error", params))
+
+      // Passed through to every attached client, so a `logs` or a `--wait`
+      // running against the session sees what the viewer sent.
+      for (const event of BROADCAST) {
+        connected.connection.peer.on(event, (params) => control?.broadcast(event, params))
+      }
+
+      connected.connection.onClose(() => {
+        if (client === connected) client = undefined
+      })
+
+      // Re-published on every reconnect: a viewer that restarted has
+      // forgotten everything the old connection published.
+      await publishTargets(connected, targets, reporter, publish)
+    },
+    onStop: async () => {
+      watcher?.close()
+      stopBuild?.()
+
+      // Waiters first: a client blocked on `wait` should be told the session
+      // is going rather than left holding a socket that just vanished.
+      for (const waiter of waiters) waiter.settle(undefined)
+
+      waiters.clear()
+
+      await control?.close()
+
+      // Flushed before the process is allowed to end: the SIGINT that stopped
+      // the session is exactly when the last line matters most.
+      await state.close()
+    },
+  })
+
+  return 0
+}

--- a/packages/viewer-client/src/cli/commands/connect.ts
+++ b/packages/viewer-client/src/cli/commands/connect.ts
@@ -577,6 +577,10 @@ export async function connectCommand(
     )
   }
 
+  // Only now the socket is ours. A start that loses the race for it exits
+  // above, rather than leaving the winner's file describing this process.
+  await state.announce()
+
   await runSession({
     // A session outlives a viewer restart by definition.
     follow: true,

--- a/packages/viewer-client/src/cli/commands/control.ts
+++ b/packages/viewer-client/src/cli/commands/control.ts
@@ -1,5 +1,7 @@
-import { readFile } from "node:fs/promises"
+import { createReadStream } from "node:fs"
+import { access } from "node:fs/promises"
 import { join } from "node:path"
+import { createInterface } from "node:readline"
 import pc from "picocolors"
 import type { ControlClient } from "../../control/client.js"
 import { LOG_FILE, stateDirectory } from "../../state.js"
@@ -67,8 +69,8 @@ export async function waitCommand(
     )
   }
 
-  // Without a cursor, "wait" means the next push, not every push this session
-  // has ever run, so the current cursor is where it starts from.
+  // Without a cursor, "wait" means the next push rather than every push this
+  // session has run, so it starts from the current one.
   const since =
     command.since && "cursor" in command.since
       ? command.since.cursor
@@ -106,9 +108,9 @@ export async function waitCommand(
 /**
  * Reads back what a session recorded, after it has gone.
  *
- * The sink is the only place output survives the session that captured it, and
- * a session that died is exactly when someone wants to know what the script
- * said, so `--since` answers from the file when no socket does.
+ * The sink is the only place output outlives the session that captured it,
+ * and a dead session is when someone wants to know what the script said, so
+ * `--since` answers from the file when no socket does.
  */
 export async function replayLogs(
   root: string,
@@ -117,10 +119,8 @@ export async function replayLogs(
 ): Promise<number> {
   const path = join(stateDirectory(root), LOG_FILE)
 
-  let text: string
-
   try {
-    text = await readFile(path, "utf8")
+    await access(path)
   } catch {
     throw new Error(
       `no session log in ${displayPath(path)}; --since reads what a "slua-viewer connect" session recorded`,
@@ -131,7 +131,12 @@ export async function replayLogs(
   const cursor = since && "cursor" in since ? since.cursor : undefined
   const records: Record<string, unknown>[] = []
 
-  for (const line of text.split("\n")) {
+  // A line at a time rather than the whole file. This caps at 5 MB before it
+  // rotates, and only the records passing the filters below are worth holding,
+  // usually a handful.
+  const lines = createInterface({ crlfDelay: Infinity, input: createReadStream(path, "utf8") })
+
+  for await (const line of lines) {
     if (line.trim() === "") continue
 
     let entry: Record<string, unknown>

--- a/packages/viewer-client/src/cli/commands/control.ts
+++ b/packages/viewer-client/src/cli/commands/control.ts
@@ -1,0 +1,160 @@
+import { readFile } from "node:fs/promises"
+import { join } from "node:path"
+import pc from "picocolors"
+import type { ControlClient } from "../../control/client.js"
+import { LOG_FILE, stateDirectory } from "../../state.js"
+import type { Command } from "../args.js"
+import { displayPath, type Reporter } from "../output.js"
+import { fromPayload, writeRecord } from "../runtime-view.js"
+
+/** How far back `--since <duration>` reaches, or which cursor it starts after. */
+export type Since = { cursor: number } | { ms: number }
+
+export function sinceParams(since: Since | undefined): { since?: number; sinceMs?: number } {
+  if (!since) return {}
+
+  return "cursor" in since ? { since: since.cursor } : { sinceMs: since.ms }
+}
+
+export async function statusCommand(control: ControlClient, reporter: Reporter): Promise<number> {
+  const status = await control.status()
+
+  reporter.data(status)
+
+  const viewer = status as unknown as {
+    connected: boolean
+    watching: boolean
+    pushing: boolean
+    cursor: number
+    logPath?: string
+    viewer?: { port?: number; name?: string }
+  }
+
+  reporter.line(
+    `${viewer.connected ? pc.green("connected") : pc.yellow("disconnected")} to ${
+      viewer.viewer?.name ?? "the viewer"
+    } on ${viewer.viewer?.port ?? "?"}`,
+  )
+
+  reporter.line(
+    `${status.watching ? "watching" : "not watching"}${status.pushing ? ", push in flight" : ""}, cursor ${viewer.cursor}`,
+  )
+
+  for (const target of status.targets) {
+    const push = target.lastPush as { ok?: boolean; compiled?: boolean } | undefined
+    const state = push
+      ? push.compiled
+        ? pc.green("compiled")
+        : pc.red("failed")
+      : pc.dim("not pushed yet")
+
+    reporter.line(`  ${target.name} → ${target.item ?? "?"}  ${state}`)
+  }
+
+  if (viewer.logPath) reporter.line(pc.dim(`  logs in ${displayPath(viewer.logPath)}`))
+
+  return 0
+}
+
+export async function waitCommand(
+  control: ControlClient,
+  command: Extract<Command, { name: "wait" }>,
+  reporter: Reporter,
+): Promise<number> {
+  if (command.since && "ms" in command.since) {
+    reporter.note(
+      pc.yellow("wait takes a cursor, not a duration; waiting for the next push instead"),
+    )
+  }
+
+  // Without a cursor, "wait" means the next push, not every push this session
+  // has ever run, so the current cursor is where it starts from.
+  const since =
+    command.since && "cursor" in command.since
+      ? command.since.cursor
+      : (await control.status()).cursor
+
+  const result = await control.wait({ since, timeoutMs: command.timeoutMs })
+
+  reporter.data(result)
+
+  if (!result.settled) {
+    reporter.note(pc.yellow("nothing settled before the timeout"))
+  }
+
+  for (const payload of result.logs) writeRecord(reporter, fromPayload(payload))
+
+  if (result.truncated > 0) {
+    reporter.note(
+      pc.dim(
+        `${result.truncated} more records; the full stream is in ${
+          result.logPath ? displayPath(result.logPath) : "the session log"
+        }`,
+      ),
+    )
+  }
+
+  const failed = result.targets.filter((target) => target.ok === false)
+
+  for (const target of failed) {
+    reporter.error(`${target.target}: ${target.compiled === false ? "compile failed" : "failed"}`)
+  }
+
+  return result.settled && failed.length === 0 ? 0 : 1
+}
+
+/**
+ * Reads back what a session recorded, after it has gone.
+ *
+ * The sink is the only place output survives the session that captured it, and
+ * a session that died is exactly when someone wants to know what the script
+ * said, so `--since` answers from the file when no socket does.
+ */
+export async function replayLogs(
+  root: string,
+  since: Since | undefined,
+  reporter: Reporter,
+): Promise<number> {
+  const path = join(stateDirectory(root), LOG_FILE)
+
+  let text: string
+
+  try {
+    text = await readFile(path, "utf8")
+  } catch {
+    throw new Error(
+      `no session log in ${displayPath(path)}; --since reads what a "slua-viewer connect" session recorded`,
+    )
+  }
+
+  const cutoff = since && "ms" in since ? Date.now() - since.ms : undefined
+  const cursor = since && "cursor" in since ? since.cursor : undefined
+  const records: Record<string, unknown>[] = []
+
+  for (const line of text.split("\n")) {
+    if (line.trim() === "") continue
+
+    let entry: Record<string, unknown>
+
+    try {
+      entry = JSON.parse(line)
+    } catch {
+      // A line half-written when the session died is not worth the whole read.
+      continue
+    }
+
+    if (entry.kind !== "runtime") continue
+    if (cursor !== undefined && Number(entry.seq ?? 0) <= cursor) continue
+    if (cutoff !== undefined && new Date(String(entry.time)).getTime() < cutoff) continue
+
+    records.push(entry)
+  }
+
+  reporter.note(
+    pc.dim(`replaying ${records.length} records from ${displayPath(path)}, no session running`),
+  )
+
+  for (const record of records) writeRecord(reporter, fromPayload(record))
+
+  return 0
+}

--- a/packages/viewer-client/src/cli/commands/link.ts
+++ b/packages/viewer-client/src/cli/commands/link.ts
@@ -18,9 +18,9 @@ import type { Reporter } from "../output.js"
 /**
  * Pairs a target with the object currently open in the viewer.
  *
- * Object UUIDs do not survive a take and re-rez, so this stamps a key into the
- * object's description, which does, and records that key in slua.json. The
- * pairing then holds even after the object is rezzed afresh.
+ * Object UUIDs do not survive a take and re-rez. Descriptions do, so this
+ * stamps a key into one and records it in slua.json, and the pairing holds
+ * after the object is rezzed afresh.
  */
 export async function linkCommand(
   client: ViewerClient,
@@ -35,7 +35,7 @@ export async function linkCommand(
   const config = await loadConfig()
   const root = config?.root ?? process.cwd()
 
-  // If the source already names the item, let it keep owning that; only the
+  // If the source already names the item, let it keep owning that. Only the
   // object pairing needs recording.
   const header = await readHeaderTagsFor(resolve(root, file))
   const item = command.item ?? header?.item ?? command.target

--- a/packages/viewer-client/src/cli/commands/logs.ts
+++ b/packages/viewer-client/src/cli/commands/logs.ts
@@ -8,6 +8,7 @@ import {
   waitForAnyPublish,
 } from "../../addressing.js"
 import type { ViewerClient } from "../../client.js"
+import type { ControlClient } from "../../control/client.js"
 import type { RuntimeDebug } from "../../protocol/types.js"
 import type { Command, GlobalFlags } from "../args.js"
 import { openClient, projectRoot } from "../connect.js"
@@ -80,12 +81,11 @@ async function streamOnce(
 
       reporter.note(pc.dim(`watching ${object.objectName} (${object.objectId})`))
     } else {
-      // Subscribed before the listing that decides whether to wait, since a
-      // publish landing between the two would otherwise be missed.
+      // Subscribed before the listing that decides whether to wait, or a
+      // publish landing between the two would be missed.
       watcher = publish.waitMs ? waitForAnyPublish(client, publish.waitMs) : undefined
 
-      // Nothing awaits it when something is already published, so swallow the
-      // timeout rather than leave it unhandled.
+      // Nothing awaits it when something is already published.
       watcher?.published.catch(() => {})
 
       // With nothing published there is nothing to forward, so either wait for
@@ -107,8 +107,8 @@ async function streamOnce(
       }
     }
   } catch (error) {
-    // The wait is the only thing here holding the event loop open; the session
-    // closes the socket itself once this rethrows.
+    // The wait is the only thing here holding the event loop open. The session
+    // closes the socket once this rethrows.
     watcher?.cancel()
 
     throw error
@@ -128,7 +128,7 @@ export async function logsCommand(
   }
 
   // Nothing to stream from, but the session that died wrote down what it saw,
-  // and that is exactly the moment someone asks what the script said.
+  // which is when someone asks what the script said.
   if (command.since && !command.follow) {
     const { client, control } = await openClient(global, reporter)
 
@@ -139,7 +139,7 @@ export async function logsCommand(
     }
 
     try {
-      await replay(client, command, reporter)
+      await replay(control, command, reporter)
     } finally {
       client.close()
     }
@@ -147,16 +147,31 @@ export async function logsCommand(
     return 0
   }
 
+  // Printed once, on the first connection. A reconnect asking again would
+  // reprint everything since the same cursor.
+  let replayed = false
+  let control: ControlClient | undefined
+
   await runSession({
     follow: command.follow,
     reporter,
-    // Through a running session when there is one: it already holds the
-    // connection, and the cursor `--since` refers to is the one it numbers.
-    connect: async () => (await openClient(global, reporter)).client,
+    // Through a running session when there is one. It already holds the
+    // connection, and it numbers the cursor `--since` refers to.
+    connect: async () => {
+      const opened = await openClient(global, reporter)
+
+      control = opened.control
+
+      return opened.client
+    },
     onConnected: async (client) => {
       // Backlog first, so a `--since` that runs into a live stream reads in
       // order rather than interleaving the two.
-      await replay(client, command, reporter)
+      if (!replayed) {
+        replayed = true
+
+        await replay(control, command, reporter)
+      }
 
       await streamOnce(client, command, reporter, targets, publish)
     },
@@ -167,13 +182,13 @@ export async function logsCommand(
 
 /** Prints what the session already has, for a `--since` that asks for it. */
 async function replay(
-  client: ViewerClient,
+  control: ControlClient | undefined,
   command: Extract<Command, { name: "logs" }>,
   reporter: Reporter,
 ): Promise<void> {
-  if (!command.since || !isControl(client)) return
+  if (!command.since || !control) return
 
-  const { logs, truncated, logPath } = await client.logs(sinceParams(command.since))
+  const { logs, truncated, logPath } = await control.logs(sinceParams(command.since))
 
   for (const payload of logs) writeRecord(reporter, fromPayload(payload))
 
@@ -182,14 +197,4 @@ async function replay(
       pc.dim(`${truncated} older records left out; the whole stream is in ${logPath ?? "the log"}`),
     )
   }
-}
-
-/** Whether the client is attached to a session rather than to the viewer. */
-function isControl(client: ViewerClient): client is ViewerClient & {
-  logs(params: {
-    since?: number
-    sinceMs?: number
-  }): Promise<{ logs: Record<string, unknown>[]; truncated: number; logPath?: string }>
-} {
-  return typeof (client as { logs?: unknown }).logs === "function"
 }

--- a/packages/viewer-client/src/cli/commands/logs.ts
+++ b/packages/viewer-client/src/cli/commands/logs.ts
@@ -1,7 +1,5 @@
-import { isAbsolute, resolve } from "node:path"
 import pc from "picocolors"
 import {
-  eachPrim,
   ensurePublished,
   parseObjectSelector,
   PUBLISH_HINT,
@@ -9,316 +7,32 @@ import {
   type PublishWatcher,
   waitForAnyPublish,
 } from "../../addressing.js"
-import { ViewerClient } from "../../client.js"
-import type {
-  ObjectUpdateMessage,
-  PublishedObject,
-  RuntimeDebug,
-  RuntimeError,
-} from "../../protocol/types.js"
-import { loadSourceMapFor, type SourceMap } from "../../sourcemap.js"
-import { loadConfig } from "../../targets.js"
+import type { ViewerClient } from "../../client.js"
+import type { RuntimeDebug } from "../../protocol/types.js"
 import type { Command, GlobalFlags } from "../args.js"
-import { displayPath, type Reporter } from "../output.js"
+import { openClient, projectRoot } from "../connect.js"
+import type { Reporter } from "../output.js"
+import { runSession } from "../session.js"
+import { replayLogs, sinceParams } from "./control.js"
+import {
+  fromPayload,
+  loadTargets,
+  objectIds,
+  type Targets,
+  toRecord,
+  wantedEvent,
+  withUpdate,
+  writeRecord,
+} from "../runtime-view.js"
 
-const RECONNECT_BASE_MS = 1_000
-const RECONNECT_MAX_MS = 30_000
-
-export interface TargetMap {
-  name: string
-  /** The item the target deploys to, when the config names one. */
-  item?: string
-  map: SourceMap
-}
-
-export interface MappedLocation {
-  target: string
-  source: string
-  line: number
-}
-
-export interface Targets {
-  maps: TargetMap[]
-  /** Lowercased item names the config's targets deploy to. */
-  items: Set<string>
-}
-
-/**
- * What `slua.json` says about the scripts this project deploys.
- *
- * Runtime output reports positions in the generated Lua (`lua_script:5`),
- * which is not a file anyone wrote, so the same maps that bring compile errors
- * home are worth having here too. The item names are what `--targets` filters
- * on, and a target without a source map still counts for that.
- */
-async function loadTargets(): Promise<Targets> {
-  const config = await loadConfig()
-  const maps: TargetMap[] = []
-  const items = new Set<string>()
-
-  if (!config) return { maps, items }
-
-  for (const [name, target] of Object.entries(config.targets)) {
-    if (target.item) items.add(target.item.toLowerCase())
-    if (!target.file) continue
-
-    const file = isAbsolute(target.file) ? target.file : resolve(config.root, target.file)
-    const map = await loadSourceMapFor(file)
-
-    if (map) maps.push({ name, item: target.item, map })
-  }
-
-  return { maps, items }
-}
-
-/**
- * A position at the head of a runtime line.
- *
- * The viewer reports the error as `lua_script:4: message` and each traceback
- * frame as a bare `lua_script:4`, so both shapes count. Anchoring the row to
- * the start of the line, and requiring a colon or the line's end after it,
- * keeps ordinary output like `http:80 responded` from reading as a position.
- */
-const RUNTIME_POSITION = /^(?:\[[^\]]*\]|[\w./\\-]*):(\d+)(?::|$)/
-
-/** The generated row a runtime line reports, or 0 when it names none. */
-export function rowIn(text: string): number {
-  const match = RUNTIME_POSITION.exec(text.trim())
-
-  return match ? Number(match[1]) : 0
-}
-
-/**
- * The maps that could describe the script an event came from.
- *
- * A viewer advertising `unifiedDiagnostics` names the item its output came
- * from, so a row that several targets' maps happen to cover need no longer be
- * reported against all of them. An event with no item, or one naming an item
- * no target claims, still falls back to every map.
- */
-export function mapsFor(params: RuntimeDebug, maps: TargetMap[]): TargetMap[] {
-  const script = params.item?.name
-
-  if (!script) return maps
-
-  const named = maps.filter((entry) => entry.item?.toLowerCase() === script.toLowerCase())
-
-  return named.length > 0 ? named : maps
-}
-
-/**
- * Every id a runtime event could name for one published object.
- *
- * A viewer advertising `unifiedDiagnostics` reports `objectId` as the
- * linkset's root and the speaking prim as `primId`; an older one puts the
- * speaking prim in `objectId` alone, so a script in a child prim never names
- * the root at all. Listing every prim matches both.
- */
-export function objectIds(object: PublishedObject): Set<string> {
-  return new Set(eachPrim(object).map((prim) => prim.primId))
-}
-
-/** Adds any prims an update brought with it. */
-export function withUpdate(ids: Set<string>, update: ObjectUpdateMessage): Set<string> {
-  const links = update.changes?.linkedObjects?.added ?? update.linkedObjects ?? []
-
-  // Only ever grows: an id that stopped being ours risks keeping a line,
-  // where forgetting one risks losing output the stream was asked for.
-  return new Set([...ids, update.objectId, ...links.map((link) => link.linkId)])
-}
-
-export function fromObject(params: RuntimeDebug, ids: Set<string>): boolean {
-  return [params.item?.rootId, params.objectId, params.primId].some(
-    (id) => id !== undefined && ids.has(id),
-  )
-}
-
-/**
- * Whether an event names an item one of the config's targets deploys to.
- *
- * A viewer that sends no item reference cannot be filtered this way, so its
- * output is kept rather than quietly dropped. `logs` says so once instead.
- */
-export function namesTarget(params: RuntimeDebug, items: Set<string>): boolean {
-  const script = params.item?.name
-
-  if (!script) return true
-
-  return items.has(script.toLowerCase())
-}
-
-/**
- * Whether a runtime event belongs to the stream the flags asked for.
- *
- * `ids` is unset until the named object resolves, a hold as long as `--wait`
- * allows, so naming one holds output back rather than letting every other
- * object's through in the meantime.
- */
-export function wantedEvent(
-  params: RuntimeDebug,
-  command: Pick<Extract<Command, { name: "logs" }>, "object" | "targets">,
-  ids: Set<string> | undefined,
-  items: Set<string>,
-): boolean {
-  if (command.object && !ids) return false
-  if (ids && !fromObject(params, ids)) return false
-
-  return !command.targets || namesTarget(params, items)
-}
-
-export function mapRow(row: number, maps: TargetMap[]): MappedLocation[] {
-  if (row <= 0) return []
-
-  return maps.flatMap(({ name, map }) => {
-    const location = map.mapRow(row)
-
-    return location ? [{ target: name, source: location.source, line: location.line }] : []
-  })
-}
-
-/**
- * Nothing here names the script that produced the output, so a row can map
- * through more than one target's map. Naming the target keeps that honest
- * rather than picking one and hoping.
- */
-function formatLocation(location: MappedLocation, ambiguous: boolean): string {
-  const where = `${displayPath(location.source)}:${location.line}`
-
-  return ambiguous ? `${where} (${location.target})` : where
-}
-
-function position(line: number, column: number): string {
-  return column > 0 ? `line ${line}, column ${column}` : `line ${line}`
-}
-
-/**
- * The text of a runtime event.
- *
- * The message is the whole raw chat line and carries the traceback with it,
- * so it wins over the viewer's extracted `error`. On a viewer without
- * `unifiedDiagnostics` both that and `line` arrive empty, and the detail
- * follows as a separate `runtime.debug` message, so an error would otherwise
- * print as a bare object name and nothing else.
- */
-export function runtimeText(params: RuntimeDebug | RuntimeError, level: "debug" | "error"): string {
-  const { error = "", line = 0, column = 0 } = params as RuntimeError
-  const text = params.message || error
-
-  if (text) {
-    if (line <= 0) return text
-
-    // The text usually names the line itself, as `lua_script:4: ...`, but it
-    // never names the column, so suppressing the whole position would lose a
-    // column the viewer went to the trouble of reporting.
-    if (!text.includes(`:${line}:`)) return `${text} (${position(line, column)})`
-
-    return column > 0 ? `${text} (column ${column})` : text
-  }
-
-  if (line > 0) return `error on ${position(line, column)}`
-
-  return level === "error"
-    ? "script error without text; an older viewer sends the detail as a separate debug message"
-    : ""
-}
-
-/**
- * One event's worth of lines, and everywhere they map back to.
- *
- * The viewer packs the error text and its traceback into a single multi-line
- * message, so a line at a time is the only way to find the positions in it.
- * Locations are deduplicated because the error line and its first traceback
- * frame report the same row.
- */
-export function runtimeLines(
-  params: RuntimeDebug | RuntimeError,
-  level: "debug" | "error",
-  maps: TargetMap[],
-): { lines: string[]; mapped: MappedLocation[] } {
-  const lines = [
-    ...runtimeText(params, level).split("\n"),
-    ...((params as RuntimeError).stack ?? []),
-  ]
-    .map((line) => line.trimEnd())
-    .filter((line) => line !== "")
-
-  const rows = new Set(lines.map(rowIn).filter((row) => row > 0))
-
-  if (rows.size === 0 && (params as RuntimeError).line > 0) {
-    rows.add((params as RuntimeError).line)
-  }
-
-  return { lines, mapped: [...rows].flatMap((row) => mapRow(row, maps)) }
-}
-
-/**
- * The tag a line carries.
- *
- * `owner_say` is the script talking to its owner rather than debug output,
- * and the two are indistinguishable without the channel the viewer now sends.
- */
-export function tagFor(level: "debug" | "error", params: RuntimeDebug): string {
-  if (level === "error") return pc.red("error")
-
-  return params.channel === "owner_say" ? pc.dim("say") : pc.dim("debug")
-}
-
-/**
- * Who produced a line.
- *
- * The same `object/item` addressing the other commands take, so a name read
- * out of the stream can be pasted straight into a `pull` or a `push`. The
- * item half needs a viewer advertising `unifiedDiagnostics`.
- */
-export function sourceName(params: RuntimeDebug): string {
-  const object = params.objectName || params.objectId
-  const script = params.item?.name
-
-  return script ? `${object}/${script}` : object
-}
-
-function emit(
-  reporter: Reporter,
-  level: "debug" | "error",
-  params: RuntimeDebug | RuntimeError,
-  maps: TargetMap[],
-) {
-  const scoped = mapsFor(params, maps)
-  const { lines, mapped } = runtimeLines(params, level, scoped)
-
-  if (reporter.json) {
-    // A stream gets one JSON object per line, not one document.
-    process.stdout.write(`${JSON.stringify({ level, ...params, mapped })}\n`)
-
-    return
-  }
-
-  const tag = tagFor(level, params)
-  const ambiguous = scoped.length > 1
-
-  reporter.line(`${tag} ${pc.bold(sourceName(params))}  ${lines[0] ?? ""}`)
-
-  // The traceback belongs to the line above it, so it is indented under it
-  // rather than tagged again as output of its own.
-  for (const line of lines.slice(1)) {
-    reporter.line(pc.dim(`      ${line}`))
-  }
-
-  for (const location of mapped) {
-    reporter.line(pc.dim(`      → ${formatLocation(location, ambiguous)}`))
-  }
-}
-
-/** One connection's worth of streaming. Resolves when the connection drops. */
+/** Subscribes one connection to the output the flags asked for. */
 async function streamOnce(
-  global: GlobalFlags,
+  client: ViewerClient,
   command: Extract<Command, { name: "logs" }>,
   reporter: Reporter,
   targets: Targets,
   publish: PublishOptions,
-): Promise<ViewerClient> {
-  const client = await ViewerClient.connect({ port: global.port, timeoutMs: global.timeoutMs })
-
+): Promise<void> {
   // The viewer forwards every published object's output to every connection,
   // so naming one object only narrows the stream if we do it here. Unset until
   // the object resolves below.
@@ -329,11 +43,11 @@ async function streamOnce(
   // Registered before the round trips below, so output produced while the
   // viewer is publishing still reaches the stream.
   client.on("runtime.debug", (params) => {
-    if (wanted(params)) emit(reporter, "debug", params, targets.maps)
+    if (wanted(params)) writeRecord(reporter, toRecord("debug", params, targets.maps))
   })
 
   client.on("runtime.error", (params) => {
-    if (wanted(params)) emit(reporter, "error", params, targets.maps)
+    if (wanted(params)) writeRecord(reporter, toRecord("error", params, targets.maps))
   })
 
   // The linkset can grow while the stream runs, and a script in a prim linked
@@ -393,15 +107,12 @@ async function streamOnce(
       }
     }
   } catch (error) {
-    // The socket is open from here on, and an open socket keeps the event loop
-    // alive, so a failed setup would hang rather than report and exit.
+    // The wait is the only thing here holding the event loop open; the session
+    // closes the socket itself once this rethrows.
     watcher?.cancel()
-    client.close()
 
     throw error
   }
-
-  return client
 }
 
 export async function logsCommand(
@@ -416,56 +127,69 @@ export async function logsCommand(
     throw new Error("--targets needs a slua.json with targets that name an item")
   }
 
-  let attempt = 0
-  let stopping = false
-  let current: ViewerClient | undefined
+  // Nothing to stream from, but the session that died wrote down what it saw,
+  // and that is exactly the moment someone asks what the script said.
+  if (command.since && !command.follow) {
+    const { client, control } = await openClient(global, reporter)
 
-  // Removed on the way out, or a caller that runs this more than once would
-  // stack a handler per call.
-  const interrupt = () => {
-    stopping = true
-    current?.close()
-    process.exit(0)
-  }
+    if (!control) {
+      client.close()
 
-  process.on("SIGINT", interrupt)
-
-  try {
-    // oxlint-disable-next-line no-unmodified-loop-condition -- set by the SIGINT handler above
-    while (!stopping) {
-      try {
-        current = await streamOnce(global, command, reporter, targets, publish)
-        attempt = 0
-
-        await new Promise<void>((resolveClosed) => {
-          current!.connection.onClose(() => resolveClosed())
-          current!.connection.peer.on("session.disconnect", () => resolveClosed())
-        })
-
-        // A `session.disconnect` can arrive with the socket still open, so the
-        // old client goes before a replacement takes its place. Already-closed
-        // connections ignore this.
-        current.close()
-      } catch (error) {
-        if (!command.follow) throw error
-
-        reporter.note(pc.dim(`disconnected: ${error instanceof Error ? error.message : error}`))
-      }
-
-      if (!command.follow || stopping) break
-
-      // Back off so a viewer that is closed or restarting isn't hammered.
-      const delay = Math.min(RECONNECT_BASE_MS * 2 ** attempt++, RECONNECT_MAX_MS)
-
-      reporter.note(pc.dim(`reconnecting in ${Math.round(delay / 1000)}s`))
-
-      await new Promise((sleep) => setTimeout(sleep, delay))
+      return await replayLogs(await projectRoot(), command.since, reporter)
     }
-  } finally {
-    process.off("SIGINT", interrupt)
+
+    try {
+      await replay(client, command, reporter)
+    } finally {
+      client.close()
+    }
+
+    return 0
   }
 
-  current?.close()
+  await runSession({
+    follow: command.follow,
+    reporter,
+    // Through a running session when there is one: it already holds the
+    // connection, and the cursor `--since` refers to is the one it numbers.
+    connect: async () => (await openClient(global, reporter)).client,
+    onConnected: async (client) => {
+      // Backlog first, so a `--since` that runs into a live stream reads in
+      // order rather than interleaving the two.
+      await replay(client, command, reporter)
+
+      await streamOnce(client, command, reporter, targets, publish)
+    },
+  })
 
   return 0
+}
+
+/** Prints what the session already has, for a `--since` that asks for it. */
+async function replay(
+  client: ViewerClient,
+  command: Extract<Command, { name: "logs" }>,
+  reporter: Reporter,
+): Promise<void> {
+  if (!command.since || !isControl(client)) return
+
+  const { logs, truncated, logPath } = await client.logs(sinceParams(command.since))
+
+  for (const payload of logs) writeRecord(reporter, fromPayload(payload))
+
+  if (truncated > 0) {
+    reporter.note(
+      pc.dim(`${truncated} older records left out; the whole stream is in ${logPath ?? "the log"}`),
+    )
+  }
+}
+
+/** Whether the client is attached to a session rather than to the viewer. */
+function isControl(client: ViewerClient): client is ViewerClient & {
+  logs(params: {
+    since?: number
+    sinceMs?: number
+  }): Promise<{ logs: Record<string, unknown>[]; truncated: number; logPath?: string }>
+} {
+  return typeof (client as { logs?: unknown }).logs === "function"
 }

--- a/packages/viewer-client/src/cli/commands/mcp.ts
+++ b/packages/viewer-client/src/cli/commands/mcp.ts
@@ -7,6 +7,9 @@ import type { Reporter } from "../output.js"
 /** Answered when the client asks for something we have never heard of. */
 const DEFAULT_PROTOCOL = "2025-06-18"
 
+/** Every protocol revision this server speaks. */
+const PROTOCOLS = new Set([DEFAULT_PROTOCOL, "2025-03-26", "2024-11-05"])
+
 const START_SESSION =
   'no slua session is running for this project. Start one in a terminal with "slua-viewer connect", then try again.'
 
@@ -41,8 +44,8 @@ const TOOLS: Tool[] = [
       },
     },
     run: async (control, args) => {
-      // The cursor comes back from before the push starts, so waiting on it
-      // cannot report the previous run's results as if they were this one's.
+      // The cursor comes from before the push starts, so waiting on it cannot
+      // report the previous run's results as this one's.
       const { cursor } = await control.pushNow(args.targets as string[] | undefined)
 
       return await control.wait({
@@ -105,10 +108,9 @@ function failure(id: unknown, code: number, message: string): void {
 /**
  * Serves MCP over stdio, backed by a running `connect`.
  *
- * Thin on purpose: the control socket already decided what an agent needs, so
- * this is a name, a schema and a call for each of them. Nothing here may write
- * to stdout except a protocol frame, which is why every human-facing message
- * in this path goes to stderr.
+ * Thin on purpose. The control socket already decided what an agent needs, so
+ * this is a name, a schema and a call for each. Nothing here writes to stdout
+ * except a protocol frame, so every human-facing message goes to stderr.
  */
 export async function mcpCommand(global: GlobalFlags, reporter: Reporter): Promise<number> {
   const quiet: Reporter = { ...reporter, json: false, data: () => {}, line: () => {} }
@@ -130,9 +132,9 @@ export async function mcpCommand(global: GlobalFlags, reporter: Reporter): Promi
 
     if (!tool) throw new Error(`unknown tool: ${name}`)
 
-    // Attached per call rather than held: a session restarted under a
-    // long-lived agent should not leave every later call talking to a socket
-    // that closed hours ago.
+    // Attached per call rather than held. A session restarted under a
+    // long-lived agent would otherwise leave every later call talking to a
+    // socket that closed hours ago.
     const control = await attach()
 
     try {
@@ -168,6 +170,10 @@ export async function mcpCommand(global: GlobalFlags, reporter: Reporter): Promi
     process.stdin.on("close", () => done(0))
     process.stdin.on("end", () => done(0))
 
+    // A broken stdin is the transport going away, same as it closing. Left
+    // unhandled it would be an uncaught error rather than a clean exit.
+    process.stdin.on("error", () => done(0))
+
     const handle = async (line: string) => {
       let message: { id?: unknown; method?: string; params?: Record<string, unknown> }
 
@@ -185,16 +191,21 @@ export async function mcpCommand(global: GlobalFlags, reporter: Reporter): Promi
       if (id === undefined || id === null) return
 
       switch (method) {
-        case "initialize":
+        case "initialize": {
+          const asked = params.protocolVersion as string | undefined
+
           result(id, {
-            // Echoed back when the client names one, so a newer client is not
-            // told its own version is unsupported by a server that is fine.
-            protocolVersion: (params.protocolVersion as string | undefined) ?? DEFAULT_PROTOCOL,
+            // Echoed only when it is a version this server speaks. Reflecting
+            // whatever the client asked for would claim support for a protocol
+            // we have never seen. The spec says to name ours instead and let
+            // the client decide whether to go on.
+            protocolVersion: asked !== undefined && PROTOCOLS.has(asked) ? asked : DEFAULT_PROTOCOL,
             capabilities: { tools: {} },
             serverInfo: { name: "slua-viewer", version: cliVersion() },
           })
 
           return
+        }
 
         case "ping":
           result(id, {})
@@ -221,8 +232,8 @@ export async function mcpCommand(global: GlobalFlags, reporter: Reporter): Promi
 
             result(id, { content: [{ type: "text", text: JSON.stringify(value, null, 2) }] })
           } catch (error) {
-            // A tool failure is a result, not a protocol error: the agent is
-            // meant to read it and decide what to do.
+            // A tool failure is a result, not a protocol error. The agent
+            // reads it and decides what to do.
             result(id, {
               isError: true,
               content: [

--- a/packages/viewer-client/src/cli/commands/mcp.ts
+++ b/packages/viewer-client/src/cli/commands/mcp.ts
@@ -1,0 +1,242 @@
+import type { ControlClient } from "../../control/client.js"
+import { cliVersion } from "../../state.js"
+import type { GlobalFlags } from "../args.js"
+import { openClient, projectRoot } from "../connect.js"
+import type { Reporter } from "../output.js"
+
+/** Answered when the client asks for something we have never heard of. */
+const DEFAULT_PROTOCOL = "2025-06-18"
+
+const START_SESSION =
+  'no slua session is running for this project. Start one in a terminal with "slua-viewer connect", then try again.'
+
+interface Tool {
+  name: string
+  description: string
+  inputSchema: Record<string, unknown>
+  run: (control: ControlClient, args: Record<string, unknown>) => Promise<unknown>
+}
+
+const TOOLS: Tool[] = [
+  {
+    name: "slua_status",
+    description:
+      "What the running slua session is doing: viewer connection, targets, the last push for each, and the current log cursor.",
+    inputSchema: { type: "object", properties: {} },
+    run: (control) => control.status(),
+  },
+  {
+    name: "slua_push",
+    description:
+      "Push the built output to the viewer now, skipping the watcher's debounce, and wait for it to settle. If you have just edited a source file, this waits for the build to produce it first, so it never deploys the build from before your edit. Returns the compile result for each target and the output the restarted script produced.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        targets: {
+          type: "array",
+          items: { type: "string" },
+          description: "Target names from slua.json. Every target when omitted.",
+        },
+        timeoutMs: { type: "number", description: "How long to wait for the push to settle." },
+      },
+    },
+    run: async (control, args) => {
+      // The cursor comes back from before the push starts, so waiting on it
+      // cannot report the previous run's results as if they were this one's.
+      const { cursor } = await control.pushNow(args.targets as string[] | undefined)
+
+      return await control.wait({
+        since: cursor,
+        timeoutMs: (args.timeoutMs as number | undefined) ?? 30_000,
+      })
+    },
+  },
+  {
+    name: "slua_wait",
+    description:
+      "Block until a push newer than a cursor has settled, then return its results and the output that followed. Use the cursor from a previous call, not a guess.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        since: { type: "number", description: "Wait for a push newer than this cursor." },
+        timeoutMs: { type: "number" },
+      },
+    },
+    run: async (control, args) => {
+      const since = (args.since as number | undefined) ?? (await control.status()).cursor
+
+      return await control.wait({ since, timeoutMs: args.timeoutMs as number | undefined })
+    },
+  },
+  {
+    name: "slua_logs",
+    description:
+      "Runtime output the session has captured, after a cursor or from the last few minutes. Capped; the full stream is in .slua/logs.jsonl.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        since: { type: "number", description: "Only output after this cursor." },
+        sinceMs: { type: "number", description: "Only output from the last this many ms." },
+        limit: { type: "number" },
+      },
+    },
+    run: (control, args) =>
+      control.logs({
+        since: args.since as number | undefined,
+        sinceMs: args.sinceMs as number | undefined,
+        limit: args.limit as number | undefined,
+      }),
+  },
+]
+
+/** One JSON-RPC message per line, which is what MCP's stdio transport is. */
+function reply(message: Record<string, unknown>): void {
+  process.stdout.write(`${JSON.stringify(message)}\n`)
+}
+
+function result(id: unknown, value: unknown): void {
+  reply({ jsonrpc: "2.0", id, result: value })
+}
+
+function failure(id: unknown, code: number, message: string): void {
+  reply({ jsonrpc: "2.0", id, error: { code, message } })
+}
+
+/**
+ * Serves MCP over stdio, backed by a running `connect`.
+ *
+ * Thin on purpose: the control socket already decided what an agent needs, so
+ * this is a name, a schema and a call for each of them. Nothing here may write
+ * to stdout except a protocol frame, which is why every human-facing message
+ * in this path goes to stderr.
+ */
+export async function mcpCommand(global: GlobalFlags, reporter: Reporter): Promise<number> {
+  const quiet: Reporter = { ...reporter, json: false, data: () => {}, line: () => {} }
+
+  const attach = async (): Promise<ControlClient> => {
+    const { client, control } = await openClient(global, quiet)
+
+    if (!control) {
+      client.close()
+
+      throw new Error(START_SESSION)
+    }
+
+    return control
+  }
+
+  const call = async (name: string, args: Record<string, unknown>) => {
+    const tool = TOOLS.find((entry) => entry.name === name)
+
+    if (!tool) throw new Error(`unknown tool: ${name}`)
+
+    // Attached per call rather than held: a session restarted under a
+    // long-lived agent should not leave every later call talking to a socket
+    // that closed hours ago.
+    const control = await attach()
+
+    try {
+      return await tool.run(control, args)
+    } finally {
+      control.close()
+    }
+  }
+
+  reporter.note(`slua mcp server for ${await projectRoot()}`)
+
+  return await new Promise<number>((done) => {
+    let buffer = ""
+
+    process.stdin.setEncoding("utf8")
+
+    process.stdin.on("data", (chunk: string) => {
+      buffer += chunk
+
+      for (;;) {
+        const end = buffer.indexOf("\n")
+
+        if (end < 0) break
+
+        const line = buffer.slice(0, end)
+
+        buffer = buffer.slice(end + 1)
+
+        if (line.trim() !== "") void handle(line)
+      }
+    })
+
+    process.stdin.on("close", () => done(0))
+    process.stdin.on("end", () => done(0))
+
+    const handle = async (line: string) => {
+      let message: { id?: unknown; method?: string; params?: Record<string, unknown> }
+
+      try {
+        message = JSON.parse(line)
+      } catch {
+        failure(null, -32700, "Parse error")
+
+        return
+      }
+
+      const { id, method, params = {} } = message
+
+      // A notification has no id and takes no answer, `initialized` included.
+      if (id === undefined || id === null) return
+
+      switch (method) {
+        case "initialize":
+          result(id, {
+            // Echoed back when the client names one, so a newer client is not
+            // told its own version is unsupported by a server that is fine.
+            protocolVersion: (params.protocolVersion as string | undefined) ?? DEFAULT_PROTOCOL,
+            capabilities: { tools: {} },
+            serverInfo: { name: "slua-viewer", version: cliVersion() },
+          })
+
+          return
+
+        case "ping":
+          result(id, {})
+
+          return
+
+        case "tools/list":
+          // The runner is ours; a client only ever sees the declaration.
+          result(id, {
+            tools: TOOLS.map((tool) => ({
+              name: tool.name,
+              description: tool.description,
+              inputSchema: tool.inputSchema,
+            })),
+          })
+
+          return
+
+        case "tools/call": {
+          const name = String(params.name ?? "")
+
+          try {
+            const value = await call(name, (params.arguments as Record<string, unknown>) ?? {})
+
+            result(id, { content: [{ type: "text", text: JSON.stringify(value, null, 2) }] })
+          } catch (error) {
+            // A tool failure is a result, not a protocol error: the agent is
+            // meant to read it and decide what to do.
+            result(id, {
+              isError: true,
+              content: [
+                { type: "text", text: error instanceof Error ? error.message : String(error) },
+              ],
+            })
+          }
+
+          return
+        }
+
+        default:
+          failure(id, -32601, `Method not found: ${method}`)
+      }
+    }
+  })
+}

--- a/packages/viewer-client/src/cli/commands/mcp.ts
+++ b/packages/viewer-client/src/cli/commands/mcp.ts
@@ -97,6 +97,14 @@ function reply(message: Record<string, unknown>): void {
   process.stdout.write(`${JSON.stringify(message)}\n`)
 }
 
+/** The most one unterminated frame may buffer before the client is refused. */
+const MAX_FRAME_BYTES = 4 * 1024 * 1024
+
+/** A JSON object, rather than the null and arrays that also type as one. */
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
 function result(id: unknown, value: unknown): void {
   reply({ jsonrpc: "2.0", id, result: value })
 }
@@ -148,6 +156,7 @@ export async function mcpCommand(global: GlobalFlags, reporter: Reporter): Promi
 
   return await new Promise<number>((done) => {
     let buffer = ""
+    let dropping = false
 
     process.stdin.setEncoding("utf8")
 
@@ -163,7 +172,31 @@ export async function mcpCommand(global: GlobalFlags, reporter: Reporter): Promi
 
         buffer = buffer.slice(end + 1)
 
-        if (line.trim() !== "") void handle(line)
+        // The tail of a frame already refused, not a frame of its own.
+        if (dropping) {
+          dropping = false
+
+          continue
+        }
+
+        if (line.trim() !== "") {
+          // A rejection here would otherwise take the server down over one frame.
+          void handle(line).catch((error: unknown) => {
+            reporter.note(`mcp: ${error instanceof Error ? error.message : String(error)}`)
+          })
+        }
+      }
+
+      // A client that never sends a newline would grow this string until the
+      // process runs out of memory. No real request comes near the cap.
+      if (buffer.length > MAX_FRAME_BYTES) {
+        buffer = ""
+
+        if (!dropping) {
+          dropping = true
+
+          failure(null, -32700, `Parse error: frame exceeded ${MAX_FRAME_BYTES} bytes`)
+        }
       }
     })
 
@@ -175,7 +208,7 @@ export async function mcpCommand(global: GlobalFlags, reporter: Reporter): Promi
     process.stdin.on("error", () => done(0))
 
     const handle = async (line: string) => {
-      let message: { id?: unknown; method?: string; params?: Record<string, unknown> }
+      let message: unknown
 
       try {
         message = JSON.parse(line)
@@ -185,10 +218,25 @@ export async function mcpCommand(global: GlobalFlags, reporter: Reporter): Promi
         return
       }
 
-      const { id, method, params = {} } = message
+      // `null` is valid JSON and not a request, and destructuring it throws.
+      if (!isObject(message)) {
+        failure(null, -32600, "Invalid Request")
+
+        return
+      }
+
+      const { id, method } = message as { id?: unknown; method?: unknown }
+
+      const params = isObject(message.params) ? message.params : {}
 
       // A notification has no id and takes no answer, `initialized` included.
       if (id === undefined || id === null) return
+
+      if (typeof method !== "string") {
+        failure(id, -32600, "Invalid Request")
+
+        return
+      }
 
       switch (method) {
         case "initialize": {
@@ -228,7 +276,7 @@ export async function mcpCommand(global: GlobalFlags, reporter: Reporter): Promi
           const name = String(params.name ?? "")
 
           try {
-            const value = await call(name, (params.arguments as Record<string, unknown>) ?? {})
+            const value = await call(name, isObject(params.arguments) ? params.arguments : {})
 
             result(id, { content: [{ type: "text", text: JSON.stringify(value, null, 2) }] })
           } catch (error) {

--- a/packages/viewer-client/src/cli/commands/objects.ts
+++ b/packages/viewer-client/src/cli/commands/objects.ts
@@ -15,16 +15,16 @@ export async function objectsCommand(
   publish: PublishOptions = {},
 ): Promise<number> {
   // Nothing is published until the viewer's publish button is pressed, and it
-  // only publishes to a client that is already connected, so waiting here is
-  // what makes that button work at all.
+  // only publishes to a client already connected, so waiting here is what
+  // makes that button work.
   const list = await listPublished(client, publish)
 
   reporter.data({
     objects: list.map((object) => ({
       objectId: object.objectId,
       objectName: object.objectName,
-      // Description keys are how targets pin to an object, so a listing that
-      // hides them cannot show what `link` stamped.
+      // Description keys are how targets pin to an object, so hiding them
+      // would hide what `link` stamped.
       objectDescription: object.objectDescription ?? "",
       region: object.region,
       canSaveBack: object.canSaveBack,

--- a/packages/viewer-client/src/cli/commands/push.test.ts
+++ b/packages/viewer-client/src/cli/commands/push.test.ts
@@ -116,8 +116,8 @@ const published: PublishedObject = {
 
 describe("pushCommand with --all", () => {
   it("keeps going after a target fails, and still reports every one", async () => {
-    // The first target names an object that is not published, so it throws;
-    // the second must still be pushed and the --json document must list both.
+    // The first target names an object that is not published, so it throws.
+    // The second must still be pushed and the --json document list both.
     const dir = await mkdtemp(join(tmpdir(), "slua-push-"))
 
     await mkdir(join(dir, "dist"))
@@ -184,7 +184,7 @@ describe("pushCommand with --wait", () => {
     )
 
     // The listing goes briefly empty after the rejected save, which a retry
-    // that kept --wait would wait out rather than simply read again.
+    // that kept --wait would sit out rather than read again.
     const listings = [[published], [], [published]]
     const notes: string[] = []
 
@@ -275,18 +275,41 @@ describe("pushCommand on a failed compile", () => {
   })
 })
 
-/** A client that talks back while the save is still in flight, as the viewer does. */
-function chattyClient(say: (emit: (message: string, objectId?: string) => void) => void) {
-  const listeners: ((params: Record<string, unknown>) => void)[] = []
+/** What a chatty client's script says while the save is in flight. */
+interface Say {
+  (message: string, objectId?: string): void
+  /** The same, as the `runtime.error` a script that threw produces. */
+  fail(error: string, line?: number, stack?: string[]): void
+}
 
-  const emit = (message: string, objectId = published.objectId) => {
-    for (const listener of listeners) {
+/** A client that talks back while the save is still in flight, as the viewer does. */
+function chattyClient(say: (emit: Say) => void) {
+  const listeners: Record<string, ((params: Record<string, unknown>) => void)[]> = {
+    "runtime.debug": [],
+    "runtime.error": [],
+  }
+
+  const base = (objectId: string) => ({
+    scriptId: "",
+    objectId,
+    objectName: "Second",
+    item: { rootId: objectId, name: "Main" },
+  })
+
+  const emit = ((message: string, objectId = published.objectId) => {
+    for (const listener of listeners["runtime.debug"]!) {
+      listener({ ...base(objectId), message })
+    }
+  }) as Say
+
+  emit.fail = (error, line = 0, stack = []) => {
+    for (const listener of listeners["runtime.error"]!) {
       listener({
-        scriptId: "",
-        objectId,
-        objectName: "Second",
-        item: { rootId: objectId, name: "Main" },
-        message,
+        ...base(published.objectId),
+        message: `${published.objectName}/Main: ${error}`,
+        error,
+        line,
+        stack,
       })
     }
   }
@@ -301,7 +324,7 @@ function chattyClient(say: (emit: (message: string, objectId?: string) => void) 
       return { success: true, compiled: true }
     },
     on: (event: string, handler: (params: Record<string, unknown>) => void) => {
-      if (event === "runtime.debug") listeners.push(handler)
+      listeners[event]?.push(handler)
 
       return () => {}
     },
@@ -326,10 +349,7 @@ async function project(): Promise<string> {
   return dir
 }
 
-async function drained(
-  say: (emit: (message: string, objectId?: string) => void) => void,
-  tail: number,
-): Promise<Record<string, unknown>> {
+async function drained(say: (emit: Say) => void, tail: number): Promise<Record<string, unknown>> {
   const dir = await project()
   const reporter = collectingReporter()
   const cwd = process.cwd()
@@ -364,6 +384,21 @@ describe("pushCommand with a drain window", () => {
     const payload = await drained((emit) => emit("not ours", "somebody-else"), 50)
 
     expect(payload.logs).toEqual([])
+  })
+
+  it("keeps a runtime error, with the line and traceback it named", async () => {
+    const payload = await drained(
+      (emit) => emit.fail("attempt to call a nil value", 12, ["Main:12", "Main:3"]),
+      50,
+    )
+
+    expect(payload.logs).toEqual([
+      expect.objectContaining({
+        level: "error",
+        error: "attempt to call a nil value",
+        line: 12,
+      }),
+    ])
   })
 
   it("skips the window entirely with --no-tail", async () => {

--- a/packages/viewer-client/src/cli/commands/push.test.ts
+++ b/packages/viewer-client/src/cli/commands/push.test.ts
@@ -93,6 +93,7 @@ function collectingReporter(): Reporter & { payload?: unknown; errors: string[] 
       this.payload = payload
     },
     line() {},
+    raw() {},
     note() {},
     error(text) {
       errors.push(text)
@@ -397,6 +398,7 @@ describe("pushCommand with a drain window", () => {
         level: "error",
         error: "attempt to call a nil value",
         line: 12,
+        stack: ["Main:12", "Main:3"],
       }),
     ])
   })

--- a/packages/viewer-client/src/cli/commands/push.test.ts
+++ b/packages/viewer-client/src/cli/commands/push.test.ts
@@ -274,3 +274,101 @@ describe("pushCommand on a failed compile", () => {
     ])
   })
 })
+
+/** A client that talks back while the save is still in flight, as the viewer does. */
+function chattyClient(say: (emit: (message: string, objectId?: string) => void) => void) {
+  const listeners: ((params: Record<string, unknown>) => void)[] = []
+
+  const emit = (message: string, objectId = published.objectId) => {
+    for (const listener of listeners) {
+      listener({
+        scriptId: "",
+        objectId,
+        objectName: "Second",
+        item: { rootId: objectId, name: "Main" },
+        message,
+      })
+    }
+  }
+
+  return {
+    objectList: async () => ({ objects: [published] }),
+    objectContentSave: async () => {
+      // The script restarts as the save lands, so its startup output is on the
+      // wire before this call returns.
+      say(emit)
+
+      return { success: true, compiled: true }
+    },
+    on: (event: string, handler: (params: Record<string, unknown>) => void) => {
+      if (event === "runtime.debug") listeners.push(handler)
+
+      return () => {}
+    },
+    connection: { onClose: () => () => {} },
+  } as unknown as ViewerClient
+}
+
+/** A one-target project, since a drain needs a resolved target to scope to. */
+async function project(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "slua-push-"))
+
+  await mkdir(join(dir, "dist"))
+  await writeFile(join(dir, "dist", "second.slua"), "-- second\n", "utf8")
+  await writeFile(
+    join(dir, "slua.json"),
+    JSON.stringify({
+      targets: { second: { file: "dist/second.slua", object: "name:Second", item: "Main" } },
+    }),
+    "utf8",
+  )
+
+  return dir
+}
+
+async function drained(
+  say: (emit: (message: string, objectId?: string) => void) => void,
+  tail: number,
+): Promise<Record<string, unknown>> {
+  const dir = await project()
+  const reporter = collectingReporter()
+  const cwd = process.cwd()
+
+  process.chdir(dir)
+
+  try {
+    await pushCommand(
+      chattyClient(say),
+      { name: "push", target: "second", all: false, tail },
+      reporter,
+    )
+  } finally {
+    process.chdir(cwd)
+
+    await rm(dir, { recursive: true, force: true })
+  }
+
+  return reporter.payload as Record<string, unknown>
+}
+
+describe("pushCommand with a drain window", () => {
+  it("keeps the output the save itself produced", async () => {
+    const payload = await drained((emit) => emit("hello from state_entry"), 50)
+
+    // Collected into the one document --json promises, not printed alongside it.
+    expect(payload.logs).toEqual([expect.objectContaining({ message: "hello from state_entry" })])
+    expect(payload.cursor).toEqual(expect.any(Number))
+  })
+
+  it("ignores output from an object the push never touched", async () => {
+    const payload = await drained((emit) => emit("not ours", "somebody-else"), 50)
+
+    expect(payload.logs).toEqual([])
+  })
+
+  it("skips the window entirely with --no-tail", async () => {
+    const payload = await drained((emit) => emit("ignored"), 0)
+
+    expect(payload).not.toHaveProperty("logs")
+  })
+})

--- a/packages/viewer-client/src/cli/commands/push.ts
+++ b/packages/viewer-client/src/cli/commands/push.ts
@@ -89,7 +89,6 @@ function lineReader() {
   }
 }
 
-/** Works out which targets a `push` invocation refers to. */
 export async function collectTargets(
   command: Extract<Command, { name: "push" }>,
   config: Config | undefined,
@@ -161,7 +160,6 @@ async function readHeader(
   return await readHeaderTagsFor(file)
 }
 
-/** The object and item one pushed target's output will name. */
 export interface PushScope {
   objectId: string
   primId: string
@@ -172,9 +170,8 @@ export interface PushScope {
  * Collects the runtime output a push produces.
  *
  * A save restarts the script, so whatever its `state_entry` says is on the
- * wire before the save call has even returned. Without something listening
- * across that gap the output lands on a closed socket and is gone, which is
- * the whole reason this exists.
+ * wire before the save call returns. With nothing listening across that gap
+ * the output lands on a closed socket and is gone.
  */
 interface Drain {
   /** Scopes the drain to a target the push resolved. */
@@ -204,9 +201,9 @@ function startDrain(
     else buffered.push(record)
   }
 
-  // IMPORTANT: subscribed before the first save, not after it. The script
-  // restarts the moment the save lands, so a subscription set up afterwards
-  // has already missed its startup output. Do not move this below the push.
+  // Subscribed before the first save, never after. The script restarts the
+  // moment the save lands, so a subscription set up afterwards has already
+  // missed its startup output. Do not move this below the push.
   const unsubscribe = [
     client.on("runtime.debug", (params) => receive("debug", params)),
     client.on("runtime.error", (params) => receive("error", params)),
@@ -252,9 +249,9 @@ function startDrain(
       }
 
       // Under --json the document has to come out whole, so a bounded drain
-      // collects rather than prints. An unbounded one cannot wait for an end
-      // that never comes, so it prints the document first and then streams,
-      // the same exception `logs --json` already makes.
+      // collects rather than prints. An unbounded one has no end to wait for,
+      // so it prints the document first and then streams, the same exception
+      // `logs --json` makes.
       const collect = reporter.json && tail !== "forever"
       const logs: Record<string, unknown>[] = []
 
@@ -320,8 +317,8 @@ export async function pushCommand(
 
   const document = targets.length === 1 ? results[0]! : { ok: failed === 0, targets: results }
 
-  // One drain at the end, scoped to every target it touched, rather than one
-  // window per target: `push --all` would otherwise wait once per script.
+  // One drain at the end scoped to every target it touched, rather than one
+  // window per target. `push --all` would otherwise wait once per script.
   if (drain) await drain.settle(document)
   else reporter.data(document)
 
@@ -331,9 +328,9 @@ export async function pushCommand(
 /**
  * Deploys one target and reports what happened.
  *
- * Exported for `connect`, which pushes on a watch event and must go through
- * exactly this path: the stale-listing retry, the vm inference and the mapped
- * diagnostics are not worth having twice.
+ * Exported for `connect`, which pushes on a watch event and must take this
+ * path. The stale-listing retry, the vm inference and the mapped diagnostics
+ * are not worth having twice.
  */
 export async function pushTarget(
   client: ViewerClient,
@@ -349,7 +346,7 @@ export async function pushTarget(
   // comes after. `logs --since` keys off it.
   const from = cursor()
 
-  // Lookup and save retry together: right after a save the viewer rejects the
+  // Lookup and save retry together. Right after a save the viewer rejects the
   // next one as "item not found in prim inventory", and a retry has to start
   // from a fresh listing. Only the first lookup waits on the publish button,
   // since a retry is for a listing that settles in milliseconds.
@@ -401,7 +398,7 @@ export async function pushTarget(
     }
   }
 
-  // A save can succeed while the compile fails; the source is stored either way.
+  // A save can succeed while the compile fails. The source is stored either way.
   if (response.compiled === false) {
     const language: CompileLanguage = vm === "luau" ? "luau" : "lsl"
     const errors = diagnosticsFrom(response, language)

--- a/packages/viewer-client/src/cli/commands/push.ts
+++ b/packages/viewer-client/src/cli/commands/push.ts
@@ -11,7 +11,13 @@ import {
 import type { ViewerClient } from "../../client.js"
 import { type CompileLanguage, diagnosticsFrom } from "../../compile-errors.js"
 import { ConnectionClosedError } from "../../protocol/errors.js"
-import type { Diagnostic, ObjectInventoryItem, ScriptVM } from "../../protocol/types.js"
+import type {
+  Diagnostic,
+  ObjectInventoryItem,
+  RuntimeDebug,
+  RuntimeError,
+  ScriptVM,
+} from "../../protocol/types.js"
 import { loadSourceMapFor, type SourceMap } from "../../sourcemap.js"
 import {
   type Config,
@@ -24,6 +30,17 @@ import {
 } from "../../targets.js"
 import type { Command } from "../args.js"
 import { displayPath, type Reporter } from "../output.js"
+import {
+  cursor,
+  fromObject,
+  loadTargets,
+  namesTarget,
+  recordPayload,
+  type RuntimeRecord,
+  type TargetMap,
+  toRecord,
+  writeRecord,
+} from "../runtime-view.js"
 
 /** What we built is a stronger signal than what the item currently is. */
 function vmFromExtension(file: string): ScriptVM | undefined {
@@ -144,6 +161,123 @@ async function readHeader(
   return await readHeaderTagsFor(file)
 }
 
+/** The object and item one pushed target's output will name. */
+export interface PushScope {
+  objectId: string
+  primId: string
+  item: string
+}
+
+/**
+ * Collects the runtime output a push produces.
+ *
+ * A save restarts the script, so whatever its `state_entry` says is on the
+ * wire before the save call has even returned. Without something listening
+ * across that gap the output lands on a closed socket and is gone, which is
+ * the whole reason this exists.
+ */
+interface Drain {
+  /** Scopes the drain to a target the push resolved. */
+  add(scope: PushScope): void
+  /** Waits the window out, printing the result document at the right moment. */
+  settle(document: Record<string, unknown>): Promise<void>
+}
+
+function startDrain(
+  client: ViewerClient,
+  reporter: Reporter,
+  maps: TargetMap[],
+  tail: number | "forever",
+): Drain {
+  const buffered: RuntimeRecord[] = []
+  const ids = new Set<string>()
+  const items = new Set<string>()
+
+  let deliver: ((record: RuntimeRecord) => void) | undefined
+
+  const receive = (level: "debug" | "error", params: RuntimeDebug | RuntimeError) => {
+    const record = toRecord(level, params, maps)
+
+    // Held until the pushes name what they touched, since output can arrive
+    // before the save call that caused it has even returned.
+    if (deliver) deliver(record)
+    else buffered.push(record)
+  }
+
+  // IMPORTANT: subscribed before the first save, not after it. The script
+  // restarts the moment the save lands, so a subscription set up afterwards
+  // has already missed its startup output. Do not move this below the push.
+  const unsubscribe = [
+    client.on("runtime.debug", (params) => receive("debug", params)),
+    client.on("runtime.error", (params) => receive("error", params)),
+  ]
+
+  const wanted = (record: RuntimeRecord) =>
+    fromObject(record.event, ids) && namesTarget(record.event, items)
+
+  /** Resolves when the window closes, the socket drops, or ctrl-c arrives. */
+  const window = () =>
+    new Promise<void>((done) => {
+      const finish = () => {
+        clearTimeout(timer)
+        offClose()
+        process.off("SIGINT", finish)
+        done()
+      }
+
+      const timer = tail === "forever" ? undefined : setTimeout(finish, tail)
+      const offClose = client.connection.onClose(finish)
+
+      if (tail === "forever") {
+        reporter.note(pc.dim("tailing output, press ctrl-c to stop"))
+        process.on("SIGINT", finish)
+      }
+    })
+
+  return {
+    add(scope) {
+      ids.add(scope.objectId)
+      ids.add(scope.primId)
+      items.add(scope.item.toLowerCase())
+    },
+
+    async settle(document) {
+      // Nothing resolved, so there is no object whose output this could be.
+      if (ids.size === 0) {
+        for (const off of unsubscribe) off()
+
+        reporter.data(document)
+
+        return
+      }
+
+      // Under --json the document has to come out whole, so a bounded drain
+      // collects rather than prints. An unbounded one cannot wait for an end
+      // that never comes, so it prints the document first and then streams,
+      // the same exception `logs --json` already makes.
+      const collect = reporter.json && tail !== "forever"
+      const logs: Record<string, unknown>[] = []
+
+      deliver = (record) => {
+        if (!wanted(record)) return
+
+        if (collect) logs.push(recordPayload(record))
+        else writeRecord(reporter, record)
+      }
+
+      if (!collect) reporter.data(document)
+
+      for (const record of buffered.splice(0)) deliver(record)
+
+      await window()
+
+      for (const off of unsubscribe) off()
+
+      if (collect) reporter.data({ ...document, logs })
+    },
+  }
+}
+
 export async function pushCommand(
   client: ViewerClient,
   command: Extract<Command, { name: "push" }>,
@@ -152,6 +286,12 @@ export async function pushCommand(
 ): Promise<number> {
   const targets = await collectTargets(command, await loadConfig())
   const results: Record<string, unknown>[] = []
+  const tail = command.tail ?? 0
+
+  // Source maps bring the drained output home to TypeScript, the same way
+  // `logs` does. Loaded before the drain so the first record already maps.
+  const drain =
+    tail === 0 ? undefined : startDrain(client, reporter, (await loadTargets()).maps, tail)
 
   let failed = 0
 
@@ -161,6 +301,7 @@ export async function pushCommand(
 
       results.push(result.payload)
 
+      if (result.scope) drain?.add(result.scope)
       if (!result.ok) failed++
     } catch (error) {
       // A dead connection will not improve for the next target, and a single
@@ -177,20 +318,36 @@ export async function pushCommand(
     }
   }
 
-  reporter.data(targets.length === 1 ? results[0] : { ok: failed === 0, targets: results })
+  const document = targets.length === 1 ? results[0]! : { ok: failed === 0, targets: results }
+
+  // One drain at the end, scoped to every target it touched, rather than one
+  // window per target: `push --all` would otherwise wait once per script.
+  if (drain) await drain.settle(document)
+  else reporter.data(document)
 
   return failed === 0 ? 0 : 1
 }
 
-async function pushTarget(
+/**
+ * Deploys one target and reports what happened.
+ *
+ * Exported for `connect`, which pushes on a watch event and must go through
+ * exactly this path: the stale-listing retry, the vm inference and the mapped
+ * diagnostics are not worth having twice.
+ */
+export async function pushTarget(
   client: ViewerClient,
   target: Target,
   reporter: Reporter,
   labelled: boolean,
   publish: PublishOptions,
-): Promise<{ ok: boolean; payload: Record<string, unknown> }> {
+): Promise<{ ok: boolean; payload: Record<string, unknown>; scope?: PushScope }> {
   const label = labelled ? `${target.name}: ` : ""
   const content = await readFile(target.file, "utf8")
+
+  // Taken before the save, so it names the point everything this push causes
+  // comes after. `logs --since` keys off it.
+  const from = cursor()
 
   // Lookup and save retry together: right after a save the viewer rejects the
   // next one as "item not found in prim inventory", and a retry has to start
@@ -225,6 +382,13 @@ async function pushTarget(
     itemId: resolved.itemId,
     item: resolved.item.name,
     vm,
+    cursor: from,
+  }
+
+  const scope: PushScope = {
+    objectId: resolved.object.objectId,
+    primId: resolved.primId,
+    item: resolved.item.name,
   }
 
   if (!response?.success) {
@@ -232,6 +396,7 @@ async function pushTarget(
 
     return {
       ok: false,
+      scope,
       payload: { ok: false, ...base, compiled: false, errors: [], message: response?.message },
     }
   }
@@ -243,7 +408,7 @@ async function pushTarget(
     const sourceMap = await loadSourceMapFor(target.file)
     const payload = await reportCompileErrors(errors, target.file, sourceMap, reporter, base, label)
 
-    return { ok: false, payload }
+    return { ok: false, scope, payload }
   }
 
   reporter.note(
@@ -256,6 +421,7 @@ async function pushTarget(
 
   return {
     ok: savedBack !== false,
+    scope,
     payload: {
       ok: savedBack !== false,
       ...base,

--- a/packages/viewer-client/src/cli/commands/script.ts
+++ b/packages/viewer-client/src/cli/commands/script.ts
@@ -15,8 +15,8 @@ export async function resetCommand(
   reporter: Reporter,
   publish: PublishOptions = {},
 ): Promise<number> {
-  // Only the first lookup waits on the publish button: a stale-listing retry is
-  // for an inventory that settles in milliseconds, not for an absent object.
+  // Only the first lookup waits on the publish button. A stale-listing retry
+  // is for an inventory that settles in milliseconds, not an absent object.
   const { target, response } = await withStaleRetry(async (attempt) => {
     const found = await resolveItem(
       client,

--- a/packages/viewer-client/src/cli/connect.ts
+++ b/packages/viewer-client/src/cli/connect.ts
@@ -7,7 +7,7 @@ import { loadConfig } from "../targets.js"
 import type { GlobalFlags } from "./args.js"
 import { displayPath, type Reporter } from "./output.js"
 
-/** The directory a session's state belongs to, which is where `slua.json` is. */
+/** The directory holding `slua.json`, which a session's state sits beside. */
 export async function projectRoot(): Promise<string> {
   return (await loadConfig())?.root ?? process.cwd()
 }
@@ -22,9 +22,8 @@ export interface OpenedClient {
  * Connects, through a running session when there is one.
  *
  * A session already holds a viewer connection, has the objects published and
- * is numbering output, so going through it means a command shares all of that
- * rather than starting again beside it. With none running this is exactly the
- * direct connection it always was.
+ * is numbering output, so going through it shares all of that rather than
+ * starting again beside it. With none running, this is the direct connection.
  */
 export async function openClient(global: GlobalFlags, reporter: Reporter): Promise<OpenedClient> {
   const direct = async (): Promise<OpenedClient> => ({
@@ -42,7 +41,7 @@ export async function openClient(global: GlobalFlags, reporter: Reporter): Promi
     const control = await attachControl(root, { timeoutMs: global.timeoutMs })
 
     if (session.version !== cliVersion()) {
-      // Reported rather than worked around: the two speak the same viewer
+      // Reported rather than worked around. The two speak the same viewer
       // protocol, but the control namespace is ours and it can move.
       reporter.note(
         pc.yellow(
@@ -54,9 +53,18 @@ export async function openClient(global: GlobalFlags, reporter: Reporter): Promi
     reporter.note(pc.dim(`through the session in ${displayPath(root)}`))
 
     return { client: control, control }
-  } catch {
-    // A session file outlives the process that wrote it, so liveness is
-    // decided by connecting, and failing to means there is nobody there.
+  } catch (error) {
+    // A session file outlives the process that wrote it, so failing to connect
+    // means nobody is there. Said out loud all the same, since a timed-out
+    // handshake is a wedged session and reads exactly like an absent one.
+    reporter.note(
+      pc.dim(
+        `could not attach to the session in ${displayPath(root)}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      ),
+    )
+
     return await direct()
   }
 }
@@ -115,9 +123,9 @@ export async function withControl<T>(
 /**
  * Turns the global flags into the policy commands resolve their targets with.
  *
- * `--wait` is the answer to the viewer publishing only when an editor client
- * is already connected: the command connects, says what it is waiting for, and
- * holds the socket open until the button is pressed.
+ * The viewer only publishes when an editor client is already connected, so
+ * `--wait` connects, says what it is waiting for, and holds the socket open
+ * until the button is pressed.
  */
 export function publishOptions(global: GlobalFlags, reporter: Reporter): PublishOptions {
   return {

--- a/packages/viewer-client/src/cli/connect.ts
+++ b/packages/viewer-client/src/cli/connect.ts
@@ -1,23 +1,78 @@
 import pc from "picocolors"
 import { PUBLISH_ACTION, type PublishOptions } from "../addressing.js"
 import { ViewerClient } from "../client.js"
+import { attachControl, type ControlClient } from "../control/client.js"
+import { cliVersion, readSession } from "../state.js"
+import { loadConfig } from "../targets.js"
 import type { GlobalFlags } from "./args.js"
-import type { Reporter } from "./output.js"
+import { displayPath, type Reporter } from "./output.js"
+
+/** The directory a session's state belongs to, which is where `slua.json` is. */
+export async function projectRoot(): Promise<string> {
+  return (await loadConfig())?.root ?? process.cwd()
+}
+
+export interface OpenedClient {
+  client: ViewerClient
+  /** Set when this went through a running `connect` rather than the viewer. */
+  control?: ControlClient
+}
+
+/**
+ * Connects, through a running session when there is one.
+ *
+ * A session already holds a viewer connection, has the objects published and
+ * is numbering output, so going through it means a command shares all of that
+ * rather than starting again beside it. With none running this is exactly the
+ * direct connection it always was.
+ */
+export async function openClient(global: GlobalFlags, reporter: Reporter): Promise<OpenedClient> {
+  const direct = async (): Promise<OpenedClient> => ({
+    client: await ViewerClient.connect({ port: global.port, timeoutMs: global.timeoutMs }),
+  })
+
+  if (global.direct) return await direct()
+
+  const root = await projectRoot()
+  const session = await readSession(root)
+
+  if (!session) return await direct()
+
+  try {
+    const control = await attachControl(root, { timeoutMs: global.timeoutMs })
+
+    if (session.version !== cliVersion()) {
+      // Reported rather than worked around: the two speak the same viewer
+      // protocol, but the control namespace is ours and it can move.
+      reporter.note(
+        pc.yellow(
+          `the session running in ${displayPath(root)} is ${session.version}, this CLI is ${cliVersion()}; restart it if something looks wrong`,
+        ),
+      )
+    }
+
+    reporter.note(pc.dim(`through the session in ${displayPath(root)}`))
+
+    return { client: control, control }
+  } catch {
+    // A session file outlives the process that wrote it, so liveness is
+    // decided by connecting, and failing to means there is nobody there.
+    return await direct()
+  }
+}
 
 /**
  * Runs `fn` against a connected viewer, then disconnects.
  *
  * Every one-shot command connects, does its thing and drops the session, so
- * nothing is left holding the viewer's single editor slot.
+ * nothing is left holding a connection it is not using.
  */
 export async function withClient<T>(
   global: GlobalFlags,
+  reporter: Reporter,
   fn: (client: ViewerClient) => Promise<T>,
 ): Promise<T> {
-  const client = await ViewerClient.connect({
-    port: global.port,
-    timeoutMs: global.timeoutMs,
-  })
+  const { client } = await openClient(global, reporter)
 
   try {
     return await fn(client)
@@ -26,6 +81,33 @@ export async function withClient<T>(
       client.close()
     } catch {
       // Disconnecting is best effort; whatever `fn` threw is the real news.
+    }
+  }
+}
+
+/** Runs `fn` against a running session, or says plainly that there is none. */
+export async function withControl<T>(
+  global: GlobalFlags,
+  reporter: Reporter,
+  fn: (control: ControlClient) => Promise<T>,
+): Promise<T> {
+  const { client, control } = await openClient(global, reporter)
+
+  if (!control) {
+    client.close()
+
+    throw new Error(
+      `no session is running for ${displayPath(await projectRoot())}; start one with "slua-viewer connect"`,
+    )
+  }
+
+  try {
+    return await fn(control)
+  } finally {
+    try {
+      control.close()
+    } catch {
+      // Best effort, as above.
     }
   }
 }

--- a/packages/viewer-client/src/cli/index.ts
+++ b/packages/viewer-client/src/cli/index.ts
@@ -9,6 +9,9 @@ import {
   ViewerUnavailableError,
 } from "../protocol/errors.js"
 import { CliUsageError, helpText, parseCliArgs } from "./args.js"
+import { connectCommand } from "./commands/connect.js"
+import { statusCommand, waitCommand } from "./commands/control.js"
+import { mcpCommand } from "./commands/mcp.js"
 import { linkCommand } from "./commands/link.js"
 import { objectsCommand } from "./commands/objects.js"
 import { logsCommand } from "./commands/logs.js"
@@ -16,7 +19,7 @@ import { pullCommand } from "./commands/pull.js"
 import { pushCommand } from "./commands/push.js"
 import { resetCommand, setRunningCommand } from "./commands/script.js"
 import { syntaxCommand } from "./commands/syntax.js"
-import { publishOptions, withClient } from "./connect.js"
+import { publishOptions, withClient, withControl } from "./connect.js"
 import { createReporter } from "./output.js"
 
 /** Whether stdout owes a JSON document, even when nothing parses. */
@@ -48,28 +51,54 @@ async function main(): Promise<number> {
     case "logs":
       return await logsCommand(global, command, reporter, publish)
 
+    case "connect":
+      return await connectCommand(global, command, reporter, publish)
+
+    case "mcp":
+      return await mcpCommand(global, reporter)
+
+    case "status":
+      return await withControl(global, reporter, (control) => statusCommand(control, reporter))
+
+    case "wait":
+      return await withControl(global, reporter, (control) =>
+        waitCommand(control, command, reporter),
+      )
+
     case "objects":
-      return await withClient(global, (client) => objectsCommand(client, reporter, publish))
+      return await withClient(global, reporter, (client) =>
+        objectsCommand(client, reporter, publish),
+      )
 
     case "pull":
-      return await withClient(global, (client) => pullCommand(client, command, reporter, publish))
+      return await withClient(global, reporter, (client) =>
+        pullCommand(client, command, reporter, publish),
+      )
 
     case "push":
-      return await withClient(global, (client) => pushCommand(client, command, reporter, publish))
+      return await withClient(global, reporter, (client) =>
+        pushCommand(client, command, reporter, publish),
+      )
 
     case "reset":
-      return await withClient(global, (client) => resetCommand(client, command, reporter, publish))
+      return await withClient(global, reporter, (client) =>
+        resetCommand(client, command, reporter, publish),
+      )
 
     case "set-running":
-      return await withClient(global, (client) =>
+      return await withClient(global, reporter, (client) =>
         setRunningCommand(client, command, reporter, publish),
       )
 
     case "syntax":
-      return await withClient(global, (client) => syntaxCommand(client, command, reporter))
+      return await withClient(global, reporter, (client) =>
+        syntaxCommand(client, command, reporter),
+      )
 
     case "link":
-      return await withClient(global, (client) => linkCommand(client, command, reporter, publish))
+      return await withClient(global, reporter, (client) =>
+        linkCommand(client, command, reporter, publish),
+      )
   }
 }
 

--- a/packages/viewer-client/src/cli/output.ts
+++ b/packages/viewer-client/src/cli/output.ts
@@ -41,5 +41,9 @@ export function createReporter(json: boolean): Reporter {
 export function displayPath(path: string): string {
   const relativePath = relative(process.cwd(), path)
 
+  // The working directory itself relativises to nothing at all, which reads as
+  // a missing path rather than as "here".
+  if (relativePath === "") return "."
+
   return relativePath.startsWith("..") && relativePath.length >= path.length ? path : relativePath
 }

--- a/packages/viewer-client/src/cli/output.ts
+++ b/packages/viewer-client/src/cli/output.ts
@@ -4,9 +4,9 @@ import pc from "picocolors"
 /**
  * Output split for the two modes.
  *
- * Under `--json`, stdout carries exactly one JSON document and nothing else,
- * so the CLI can be piped into `jq` or read by an agent; every human-facing
- * message goes to stderr instead.
+ * Under `--json`, stdout carries one JSON document and nothing else, so the
+ * CLI can be piped into `jq` or read by an agent. Every human-facing message
+ * goes to stderr.
  */
 export interface Reporter {
   readonly json: boolean
@@ -14,6 +14,13 @@ export interface Reporter {
   data(payload: unknown): void
   /** Human-facing output. Suppressed in JSON mode. */
   line(text?: string): void
+  /**
+   * One line straight to stdout, whatever the mode.
+   *
+   * For a stream, the one thing `data` cannot express. `--json` there means one
+   * JSON object per line rather than one document for the command.
+   */
+  raw(text: string): void
   /** Progress and warnings. Always stderr, so it never pollutes piped output. */
   note(text: string): void
   error(text: string): void
@@ -27,6 +34,9 @@ export function createReporter(json: boolean): Reporter {
     },
     line(text = "") {
       if (!json) process.stdout.write(`${text}\n`)
+    },
+    raw(text) {
+      process.stdout.write(`${text}\n`)
     },
     note(text) {
       process.stderr.write(`${text}\n`)

--- a/packages/viewer-client/src/cli/runtime-view.test.ts
+++ b/packages/viewer-client/src/cli/runtime-view.test.ts
@@ -1,19 +1,22 @@
 import { describe, expect, it } from "bun:test"
-import { SourceMap } from "../../sourcemap"
+import { SourceMap } from "../sourcemap"
 import {
+  cursor,
   fromObject,
   mapRow,
   mapsFor,
   namesTarget,
   objectIds,
+  recordPayload,
   rowIn,
   runtimeLines,
   runtimeText,
   sourceName,
   tagFor,
+  toRecord,
   wantedEvent,
   withUpdate,
-} from "./logs"
+} from "./runtime-view"
 
 // Generated line 1 -> source line 1, generated line 2 -> source line 3.
 const map = SourceMap.parse(
@@ -282,5 +285,24 @@ describe("wantedEvent", () => {
         items,
       ),
     ).toBe(false)
+  })
+})
+
+describe("toRecord", () => {
+  it("numbers events in order and stamps them", () => {
+    const first = toRecord("debug", { ...event, message: "one" }, [])
+    const second = toRecord("debug", { ...event, message: "two" }, [])
+
+    expect(second.seq).toBe(first.seq + 1)
+    expect(cursor()).toBe(second.seq)
+    expect(new Date(second.time).getTime()).not.toBeNaN()
+  })
+
+  it("carries the sequence and stamp into the JSON shape", () => {
+    const record = toRecord("error", { ...event, message: "boom" }, [])
+
+    expect(recordPayload(record)).toEqual(
+      expect.objectContaining({ seq: record.seq, time: record.time, level: "error", mapped: [] }),
+    )
   })
 })

--- a/packages/viewer-client/src/cli/runtime-view.ts
+++ b/packages/viewer-client/src/cli/runtime-view.ts
@@ -34,9 +34,9 @@ export interface Targets {
  * What `slua.json` says about the scripts this project deploys.
  *
  * Runtime output reports positions in the generated Lua (`lua_script:5`),
- * which is not a file anyone wrote, so the same maps that bring compile errors
- * home are worth having here too. The item names are what `--targets` filters
- * on, and a target without a source map still counts for that.
+ * which nobody wrote, so the maps that bring compile errors home are worth
+ * having here too. `--targets` filters on the item names, and a target with no
+ * source map still counts for that.
  */
 export async function loadTargets(): Promise<Targets> {
   const config = await loadConfig()
@@ -61,10 +61,10 @@ export async function loadTargets(): Promise<Targets> {
 /**
  * A position at the head of a runtime line.
  *
- * The viewer reports the error as `lua_script:4: message` and each traceback
- * frame as a bare `lua_script:4`, so both shapes count. Anchoring the row to
- * the start of the line, and requiring a colon or the line's end after it,
- * keeps ordinary output like `http:80 responded` from reading as a position.
+ * The viewer reports an error as `lua_script:4: message` and each traceback
+ * frame as a bare `lua_script:4`. Anchoring to the start of the line and
+ * requiring a colon or the line's end after the row keeps ordinary output like
+ * `http:80 responded` from reading as a position.
  */
 const RUNTIME_POSITION = /^(?:\[[^\]]*\]|[\w./\\-]*):(\d+)(?::|$)/
 
@@ -78,10 +78,9 @@ export function rowIn(text: string): number {
 /**
  * The maps that could describe the script an event came from.
  *
- * A viewer advertising `unifiedDiagnostics` names the item its output came
- * from, so a row that several targets' maps happen to cover need no longer be
- * reported against all of them. An event with no item, or one naming an item
- * no target claims, still falls back to every map.
+ * A viewer advertising `unifiedDiagnostics` names the item, so a row several
+ * maps happen to cover is no longer reported against all of them. An event
+ * with no item, or naming one no target claims, falls back to every map.
  */
 export function mapsFor(params: RuntimeDebug, maps: TargetMap[]): TargetMap[] {
   const script = params.item?.name
@@ -97,15 +96,14 @@ export function mapsFor(params: RuntimeDebug, maps: TargetMap[]): TargetMap[] {
  * Every id a runtime event could name for one published object.
  *
  * A viewer advertising `unifiedDiagnostics` reports `objectId` as the
- * linkset's root and the speaking prim as `primId`; an older one puts the
+ * linkset's root and the speaking prim as `primId`. An older one puts the
  * speaking prim in `objectId` alone, so a script in a child prim never names
- * the root at all. Listing every prim matches both.
+ * the root. Listing every prim matches both.
  */
 export function objectIds(object: PublishedObject): Set<string> {
   return new Set(eachPrim(object).map((prim) => prim.primId))
 }
 
-/** Adds any prims an update brought with it. */
 export function withUpdate(ids: Set<string>, update: ObjectUpdateMessage): Set<string> {
   const links = update.changes?.linkedObjects?.added ?? update.linkedObjects ?? []
 
@@ -124,7 +122,7 @@ export function fromObject(params: RuntimeDebug, ids: Set<string>): boolean {
  * Whether an event names an item one of the config's targets deploys to.
  *
  * A viewer that sends no item reference cannot be filtered this way, so its
- * output is kept rather than quietly dropped. `logs` says so once instead.
+ * output is kept and `logs` says so once.
  */
 export function namesTarget(params: RuntimeDebug, items: Set<string>): boolean {
   const script = params.item?.name
@@ -137,9 +135,9 @@ export function namesTarget(params: RuntimeDebug, items: Set<string>): boolean {
 /**
  * Whether a runtime event belongs to the stream the flags asked for.
  *
- * `ids` is unset until the named object resolves, a hold as long as `--wait`
- * allows, so naming one holds output back rather than letting every other
- * object's through in the meantime.
+ * `ids` is unset until the named object resolves, which under `--wait` can
+ * take minutes. Naming an object holds output back for that long rather than
+ * letting every other object's through in the meantime.
  */
 export function wantedEvent(
   params: RuntimeDebug,
@@ -164,9 +162,8 @@ export function mapRow(row: number, maps: TargetMap[]): MappedLocation[] {
 }
 
 /**
- * Nothing here names the script that produced the output, so a row can map
- * through more than one target's map. Naming the target keeps that honest
- * rather than picking one and hoping.
+ * A row can map through more than one target's map, and nothing here names the
+ * script that produced it. Naming the target beats picking one and hoping.
  */
 function formatLocation(location: MappedLocation, ambiguous: boolean): string {
   const where = `${displayPath(location.source)}:${location.line}`
@@ -181,11 +178,10 @@ function position(line: number, column: number): string {
 /**
  * The text of a runtime event.
  *
- * The message is the whole raw chat line and carries the traceback with it,
- * so it wins over the viewer's extracted `error`. On a viewer without
- * `unifiedDiagnostics` both that and `line` arrive empty, and the detail
- * follows as a separate `runtime.debug` message, so an error would otherwise
- * print as a bare object name and nothing else.
+ * `message` is the whole raw chat line and carries the traceback, so it wins
+ * over the viewer's extracted `error`. Without `unifiedDiagnostics` both that
+ * and `line` arrive empty and the detail follows as a separate `runtime.debug`
+ * message, which would otherwise print as a bare object name.
  */
 export function runtimeText(params: RuntimeDebug | RuntimeError, level: "debug" | "error"): string {
   const { error = "", line = 0, column = 0 } = params as RuntimeError
@@ -194,9 +190,9 @@ export function runtimeText(params: RuntimeDebug | RuntimeError, level: "debug" 
   if (text) {
     if (line <= 0) return text
 
-    // The text usually names the line itself, as `lua_script:4: ...`, but it
-    // never names the column, so suppressing the whole position would lose a
-    // column the viewer went to the trouble of reporting.
+    // The text usually names the line itself, as `lua_script:4: ...`, but
+    // never the column, so suppressing the whole position would lose one the
+    // viewer went to the trouble of reporting.
     if (!text.includes(`:${line}:`)) return `${text} (${position(line, column)})`
 
     return column > 0 ? `${text} (column ${column})` : text
@@ -212,10 +208,10 @@ export function runtimeText(params: RuntimeDebug | RuntimeError, level: "debug" 
 /**
  * One event's worth of lines, and everywhere they map back to.
  *
- * The viewer packs the error text and its traceback into a single multi-line
+ * The viewer packs the error text and its traceback into one multi-line
  * message, so a line at a time is the only way to find the positions in it.
- * Locations are deduplicated because the error line and its first traceback
- * frame report the same row.
+ * Rows are deduplicated: the error line and its first traceback frame report
+ * the same one.
  */
 export function runtimeLines(
   params: RuntimeDebug | RuntimeError,
@@ -239,10 +235,8 @@ export function runtimeLines(
 }
 
 /**
- * The tag a line carries.
- *
- * `owner_say` is the script talking to its owner rather than debug output,
- * and the two are indistinguishable without the channel the viewer now sends.
+ * `owner_say` is the script talking to its owner rather than debug output. The
+ * two are indistinguishable without the channel the viewer now sends.
  */
 export function tagFor(level: "debug" | "error", params: RuntimeDebug): string {
   if (level === "error") return pc.red("error")
@@ -251,11 +245,9 @@ export function tagFor(level: "debug" | "error", params: RuntimeDebug): string {
 }
 
 /**
- * Who produced a line.
- *
- * The same `object/item` addressing the other commands take, so a name read
- * out of the stream can be pasted straight into a `pull` or a `push`. The
- * item half needs a viewer advertising `unifiedDiagnostics`.
+ * Who produced a line, in the `object/item` addressing the other commands take,
+ * so a name read out of the stream pastes straight into a `pull` or a `push`.
+ * The item half needs a viewer advertising `unifiedDiagnostics`.
  */
 export function sourceName(params: RuntimeDebug): string {
   const object = params.objectName || params.objectId
@@ -267,10 +259,9 @@ export function sourceName(params: RuntimeDebug): string {
 /**
  * Numbers every runtime event this process has formatted.
  *
- * Monotonic and process-local. It exists so a caller can say "output after
- * this point", which is what the drain window on `push`, `logs --since` and an
- * agent waiting on the next push all ask for. Nothing needs it to survive a
- * restart.
+ * Monotonic and process-local, so a caller can say "output after this point".
+ * That is what `push --tail`, `logs --since` and an agent waiting on the next
+ * push all ask for. Nothing needs it to survive a restart.
  */
 let sequence = 0
 
@@ -282,19 +273,18 @@ export function cursor(): number {
 /**
  * Takes the next number in the sequence.
  *
- * A push takes one so it has a position of its own in the same ordering the
- * output has. That is what lets "wait for a push newer than this cursor" be
- * asked without ambiguity: a push's number is never shared with an event.
+ * A push takes one too, so it has a position in the same ordering as the
+ * output and never shares a number with an event. That is what makes "wait for
+ * a push newer than this cursor" unambiguous.
  */
 export function nextCursor(): number {
   return ++sequence
 }
 
-/** One formatted runtime event, ready to print or to collect. */
 export interface RuntimeRecord {
   /** Position in this process's event stream. */
   seq: number
-  /** When the event was formatted, which is as close as we get to when it happened. */
+  /** When the event was formatted, the closest we get to when it happened. */
   time: string
   level: "debug" | "error"
   event: RuntimeDebug | RuntimeError
@@ -306,10 +296,8 @@ export interface RuntimeRecord {
 }
 
 /**
- * Formats a runtime event without printing it.
- *
- * Nothing here writes to stdout, so a caller that wants to collect events
- * rather than stream them, as `push --tail` does, gets the same shape `logs`
+ * Formats a runtime event without printing it, so a caller collecting events
+ * rather than streaming them, as `push --tail` does, gets the shape `logs`
  * prints.
  */
 export function toRecord(
@@ -320,8 +308,8 @@ export function toRecord(
   const scoped = mapsFor(event, maps)
   const { lines, mapped } = runtimeLines(event, level, scoped)
 
-  // Numbered here rather than at each call site, so every path that formats an
-  // event lands in the same sequence.
+  // Numbered here, not at each call site, so every path that formats an event
+  // lands in the same sequence.
   return {
     seq: nextCursor(),
     time: new Date().toISOString(),
@@ -347,9 +335,8 @@ export function recordPayload(record: RuntimeRecord): Record<string, unknown> {
 /**
  * Rebuilds a record from one this process wrote earlier.
  *
- * A replayed line has already been mapped and numbered, so nothing here
- * recomputes either: reading `.slua/logs.jsonl` back has to print what was
- * printed at the time, not what today's source maps would say about it.
+ * Nothing is remapped or renumbered. Reading `.slua/logs.jsonl` back has to
+ * print what was printed at the time, not what today's source maps say.
  */
 export function fromPayload(payload: Record<string, unknown>): RuntimeRecord {
   const level = payload.level === "error" ? "error" : "debug"
@@ -372,7 +359,7 @@ export function fromPayload(payload: Record<string, unknown>): RuntimeRecord {
 export function writeRecord(reporter: Reporter, record: RuntimeRecord): void {
   if (reporter.json) {
     // A stream gets one JSON object per line, not one document.
-    process.stdout.write(`${JSON.stringify(recordPayload(record))}\n`)
+    reporter.raw(JSON.stringify(recordPayload(record)))
 
     return
   }

--- a/packages/viewer-client/src/cli/runtime-view.ts
+++ b/packages/viewer-client/src/cli/runtime-view.ts
@@ -1,0 +1,393 @@
+import { isAbsolute, resolve } from "node:path"
+import pc from "picocolors"
+import { eachPrim } from "../addressing.js"
+import type {
+  ObjectUpdateMessage,
+  PublishedObject,
+  RuntimeDebug,
+  RuntimeError,
+} from "../protocol/types.js"
+import { loadSourceMapFor, type SourceMap } from "../sourcemap.js"
+import { loadConfig } from "../targets.js"
+import { displayPath, type Reporter } from "./output.js"
+
+export interface TargetMap {
+  name: string
+  /** The item the target deploys to, when the config names one. */
+  item?: string
+  map: SourceMap
+}
+
+export interface MappedLocation {
+  target: string
+  source: string
+  line: number
+}
+
+export interface Targets {
+  maps: TargetMap[]
+  /** Lowercased item names the config's targets deploy to. */
+  items: Set<string>
+}
+
+/**
+ * What `slua.json` says about the scripts this project deploys.
+ *
+ * Runtime output reports positions in the generated Lua (`lua_script:5`),
+ * which is not a file anyone wrote, so the same maps that bring compile errors
+ * home are worth having here too. The item names are what `--targets` filters
+ * on, and a target without a source map still counts for that.
+ */
+export async function loadTargets(): Promise<Targets> {
+  const config = await loadConfig()
+  const maps: TargetMap[] = []
+  const items = new Set<string>()
+
+  if (!config) return { maps, items }
+
+  for (const [name, target] of Object.entries(config.targets)) {
+    if (target.item) items.add(target.item.toLowerCase())
+    if (!target.file) continue
+
+    const file = isAbsolute(target.file) ? target.file : resolve(config.root, target.file)
+    const map = await loadSourceMapFor(file)
+
+    if (map) maps.push({ name, item: target.item, map })
+  }
+
+  return { maps, items }
+}
+
+/**
+ * A position at the head of a runtime line.
+ *
+ * The viewer reports the error as `lua_script:4: message` and each traceback
+ * frame as a bare `lua_script:4`, so both shapes count. Anchoring the row to
+ * the start of the line, and requiring a colon or the line's end after it,
+ * keeps ordinary output like `http:80 responded` from reading as a position.
+ */
+const RUNTIME_POSITION = /^(?:\[[^\]]*\]|[\w./\\-]*):(\d+)(?::|$)/
+
+/** The generated row a runtime line reports, or 0 when it names none. */
+export function rowIn(text: string): number {
+  const match = RUNTIME_POSITION.exec(text.trim())
+
+  return match ? Number(match[1]) : 0
+}
+
+/**
+ * The maps that could describe the script an event came from.
+ *
+ * A viewer advertising `unifiedDiagnostics` names the item its output came
+ * from, so a row that several targets' maps happen to cover need no longer be
+ * reported against all of them. An event with no item, or one naming an item
+ * no target claims, still falls back to every map.
+ */
+export function mapsFor(params: RuntimeDebug, maps: TargetMap[]): TargetMap[] {
+  const script = params.item?.name
+
+  if (!script) return maps
+
+  const named = maps.filter((entry) => entry.item?.toLowerCase() === script.toLowerCase())
+
+  return named.length > 0 ? named : maps
+}
+
+/**
+ * Every id a runtime event could name for one published object.
+ *
+ * A viewer advertising `unifiedDiagnostics` reports `objectId` as the
+ * linkset's root and the speaking prim as `primId`; an older one puts the
+ * speaking prim in `objectId` alone, so a script in a child prim never names
+ * the root at all. Listing every prim matches both.
+ */
+export function objectIds(object: PublishedObject): Set<string> {
+  return new Set(eachPrim(object).map((prim) => prim.primId))
+}
+
+/** Adds any prims an update brought with it. */
+export function withUpdate(ids: Set<string>, update: ObjectUpdateMessage): Set<string> {
+  const links = update.changes?.linkedObjects?.added ?? update.linkedObjects ?? []
+
+  // Only ever grows: an id that stopped being ours risks keeping a line,
+  // where forgetting one risks losing output the stream was asked for.
+  return new Set([...ids, update.objectId, ...links.map((link) => link.linkId)])
+}
+
+export function fromObject(params: RuntimeDebug, ids: Set<string>): boolean {
+  return [params.item?.rootId, params.objectId, params.primId].some(
+    (id) => id !== undefined && ids.has(id),
+  )
+}
+
+/**
+ * Whether an event names an item one of the config's targets deploys to.
+ *
+ * A viewer that sends no item reference cannot be filtered this way, so its
+ * output is kept rather than quietly dropped. `logs` says so once instead.
+ */
+export function namesTarget(params: RuntimeDebug, items: Set<string>): boolean {
+  const script = params.item?.name
+
+  if (!script) return true
+
+  return items.has(script.toLowerCase())
+}
+
+/**
+ * Whether a runtime event belongs to the stream the flags asked for.
+ *
+ * `ids` is unset until the named object resolves, a hold as long as `--wait`
+ * allows, so naming one holds output back rather than letting every other
+ * object's through in the meantime.
+ */
+export function wantedEvent(
+  params: RuntimeDebug,
+  command: { object?: string; targets?: boolean },
+  ids: Set<string> | undefined,
+  items: Set<string>,
+): boolean {
+  if (command.object && !ids) return false
+  if (ids && !fromObject(params, ids)) return false
+
+  return !command.targets || namesTarget(params, items)
+}
+
+export function mapRow(row: number, maps: TargetMap[]): MappedLocation[] {
+  if (row <= 0) return []
+
+  return maps.flatMap(({ name, map }) => {
+    const location = map.mapRow(row)
+
+    return location ? [{ target: name, source: location.source, line: location.line }] : []
+  })
+}
+
+/**
+ * Nothing here names the script that produced the output, so a row can map
+ * through more than one target's map. Naming the target keeps that honest
+ * rather than picking one and hoping.
+ */
+function formatLocation(location: MappedLocation, ambiguous: boolean): string {
+  const where = `${displayPath(location.source)}:${location.line}`
+
+  return ambiguous ? `${where} (${location.target})` : where
+}
+
+function position(line: number, column: number): string {
+  return column > 0 ? `line ${line}, column ${column}` : `line ${line}`
+}
+
+/**
+ * The text of a runtime event.
+ *
+ * The message is the whole raw chat line and carries the traceback with it,
+ * so it wins over the viewer's extracted `error`. On a viewer without
+ * `unifiedDiagnostics` both that and `line` arrive empty, and the detail
+ * follows as a separate `runtime.debug` message, so an error would otherwise
+ * print as a bare object name and nothing else.
+ */
+export function runtimeText(params: RuntimeDebug | RuntimeError, level: "debug" | "error"): string {
+  const { error = "", line = 0, column = 0 } = params as RuntimeError
+  const text = params.message || error
+
+  if (text) {
+    if (line <= 0) return text
+
+    // The text usually names the line itself, as `lua_script:4: ...`, but it
+    // never names the column, so suppressing the whole position would lose a
+    // column the viewer went to the trouble of reporting.
+    if (!text.includes(`:${line}:`)) return `${text} (${position(line, column)})`
+
+    return column > 0 ? `${text} (column ${column})` : text
+  }
+
+  if (line > 0) return `error on ${position(line, column)}`
+
+  return level === "error"
+    ? "script error without text; an older viewer sends the detail as a separate debug message"
+    : ""
+}
+
+/**
+ * One event's worth of lines, and everywhere they map back to.
+ *
+ * The viewer packs the error text and its traceback into a single multi-line
+ * message, so a line at a time is the only way to find the positions in it.
+ * Locations are deduplicated because the error line and its first traceback
+ * frame report the same row.
+ */
+export function runtimeLines(
+  params: RuntimeDebug | RuntimeError,
+  level: "debug" | "error",
+  maps: TargetMap[],
+): { lines: string[]; mapped: MappedLocation[] } {
+  const lines = [
+    ...runtimeText(params, level).split("\n"),
+    ...((params as RuntimeError).stack ?? []),
+  ]
+    .map((line) => line.trimEnd())
+    .filter((line) => line !== "")
+
+  const rows = new Set(lines.map(rowIn).filter((row) => row > 0))
+
+  if (rows.size === 0 && (params as RuntimeError).line > 0) {
+    rows.add((params as RuntimeError).line)
+  }
+
+  return { lines, mapped: [...rows].flatMap((row) => mapRow(row, maps)) }
+}
+
+/**
+ * The tag a line carries.
+ *
+ * `owner_say` is the script talking to its owner rather than debug output,
+ * and the two are indistinguishable without the channel the viewer now sends.
+ */
+export function tagFor(level: "debug" | "error", params: RuntimeDebug): string {
+  if (level === "error") return pc.red("error")
+
+  return params.channel === "owner_say" ? pc.dim("say") : pc.dim("debug")
+}
+
+/**
+ * Who produced a line.
+ *
+ * The same `object/item` addressing the other commands take, so a name read
+ * out of the stream can be pasted straight into a `pull` or a `push`. The
+ * item half needs a viewer advertising `unifiedDiagnostics`.
+ */
+export function sourceName(params: RuntimeDebug): string {
+  const object = params.objectName || params.objectId
+  const script = params.item?.name
+
+  return script ? `${object}/${script}` : object
+}
+
+/**
+ * Numbers every runtime event this process has formatted.
+ *
+ * Monotonic and process-local. It exists so a caller can say "output after
+ * this point", which is what the drain window on `push`, `logs --since` and an
+ * agent waiting on the next push all ask for. Nothing needs it to survive a
+ * restart.
+ */
+let sequence = 0
+
+/** The last sequence number handed out, without consuming one. */
+export function cursor(): number {
+  return sequence
+}
+
+/**
+ * Takes the next number in the sequence.
+ *
+ * A push takes one so it has a position of its own in the same ordering the
+ * output has. That is what lets "wait for a push newer than this cursor" be
+ * asked without ambiguity: a push's number is never shared with an event.
+ */
+export function nextCursor(): number {
+  return ++sequence
+}
+
+/** One formatted runtime event, ready to print or to collect. */
+export interface RuntimeRecord {
+  /** Position in this process's event stream. */
+  seq: number
+  /** When the event was formatted, which is as close as we get to when it happened. */
+  time: string
+  level: "debug" | "error"
+  event: RuntimeDebug | RuntimeError
+  /** The message split into its text and traceback, blank lines dropped. */
+  lines: string[]
+  mapped: MappedLocation[]
+  /** Whether more than one target's map could describe this event. */
+  ambiguous: boolean
+}
+
+/**
+ * Formats a runtime event without printing it.
+ *
+ * Nothing here writes to stdout, so a caller that wants to collect events
+ * rather than stream them, as `push --tail` does, gets the same shape `logs`
+ * prints.
+ */
+export function toRecord(
+  level: "debug" | "error",
+  event: RuntimeDebug | RuntimeError,
+  maps: TargetMap[],
+): RuntimeRecord {
+  const scoped = mapsFor(event, maps)
+  const { lines, mapped } = runtimeLines(event, level, scoped)
+
+  // Numbered here rather than at each call site, so every path that formats an
+  // event lands in the same sequence.
+  return {
+    seq: nextCursor(),
+    time: new Date().toISOString(),
+    level,
+    event,
+    lines,
+    mapped,
+    ambiguous: scoped.length > 1,
+  }
+}
+
+/** The JSON shape a record serialises to, in `--json` output and in logs. */
+export function recordPayload(record: RuntimeRecord): Record<string, unknown> {
+  return {
+    seq: record.seq,
+    time: record.time,
+    level: record.level,
+    ...record.event,
+    mapped: record.mapped,
+  }
+}
+
+/**
+ * Rebuilds a record from one this process wrote earlier.
+ *
+ * A replayed line has already been mapped and numbered, so nothing here
+ * recomputes either: reading `.slua/logs.jsonl` back has to print what was
+ * printed at the time, not what today's source maps would say about it.
+ */
+export function fromPayload(payload: Record<string, unknown>): RuntimeRecord {
+  const level = payload.level === "error" ? "error" : "debug"
+  const event = payload as unknown as RuntimeDebug | RuntimeError
+  const mapped = (payload.mapped as MappedLocation[] | undefined) ?? []
+  const { lines } = runtimeLines(event, level, [])
+
+  return {
+    seq: Number(payload.seq ?? 0),
+    time: String(payload.time ?? ""),
+    level,
+    event,
+    lines,
+    mapped,
+    ambiguous: new Set(mapped.map((location) => location.target)).size > 1,
+  }
+}
+
+/** Prints a record, as one NDJSON line under `--json` and as text otherwise. */
+export function writeRecord(reporter: Reporter, record: RuntimeRecord): void {
+  if (reporter.json) {
+    // A stream gets one JSON object per line, not one document.
+    process.stdout.write(`${JSON.stringify(recordPayload(record))}\n`)
+
+    return
+  }
+
+  const tag = tagFor(record.level, record.event)
+
+  reporter.line(`${tag} ${pc.bold(sourceName(record.event))}  ${record.lines[0] ?? ""}`)
+
+  // The traceback belongs to the line above it, so it is indented under it
+  // rather than tagged again as output of its own.
+  for (const line of record.lines.slice(1)) {
+    reporter.line(pc.dim(`      ${line}`))
+  }
+
+  for (const location of record.mapped) {
+    reporter.line(pc.dim(`      → ${formatLocation(location, record.ambiguous)}`))
+  }
+}

--- a/packages/viewer-client/src/cli/session.ts
+++ b/packages/viewer-client/src/cli/session.ts
@@ -25,10 +25,9 @@ export interface SessionOptions {
 /**
  * Resolves when the connection drops, or when `interrupted` is called.
  *
- * Closing the connection ourselves does not reach `onClose`: `close()` marks
- * the connection disposed before the transport reports back, and that is the
- * check that stops listeners firing twice. So an interrupt has to end this
- * wait directly rather than through the close it triggers.
+ * Closing the connection ourselves does not reach `onClose`. `close()` marks
+ * it disposed before the transport reports back, and that check is what stops
+ * listeners firing twice, so an interrupt has to end this wait directly.
  */
 function untilClosed(client: ViewerClient, interrupted: (end: () => void) => void): Promise<void> {
   return new Promise<void>((done) => {
@@ -42,12 +41,12 @@ function untilClosed(client: ViewerClient, interrupted: (end: () => void) => voi
 /**
  * Holds a viewer connection, reconnecting with backoff while it is asked to.
  *
- * Shared by `logs -f` and `connect`, which want the same loop for different
- * reasons: one to keep a stream alive, the other to keep a session alive.
+ * Shared by `logs -f`, keeping a stream alive, and `connect`, keeping a
+ * session alive.
  *
  * Interrupting returns rather than calling `process.exit`, so a caller with
- * buffered writes gets to flush them. A crash is exactly when a log file
- * matters, and half a line in it is worse than none.
+ * buffered writes gets to flush them. Half a line in a log file is worse than
+ * none, and a crash is when that file matters most.
  */
 export async function runSession({
   connect,
@@ -90,6 +89,14 @@ export async function runSession({
           throw error
         }
 
+        // An interrupt during setup has already closed the client, and
+        // `untilClosed` would then wait for a close that has been and gone.
+        if (stopping) {
+          client.close()
+
+          break
+        }
+
         attempt = 0
 
         await untilClosed(client, (end) => {
@@ -99,8 +106,7 @@ export async function runSession({
         wake = undefined
 
         // A `session.disconnect` can arrive with the socket still open, so the
-        // old client goes before a replacement takes its place. Already-closed
-        // connections ignore this.
+        // old client goes before a replacement takes its place.
         client.close()
       } catch (error) {
         if (!follow) throw error

--- a/packages/viewer-client/src/cli/session.ts
+++ b/packages/viewer-client/src/cli/session.ts
@@ -79,6 +79,14 @@ export async function runSession({
 
         current = client
 
+        // An interrupt during the connect had nothing to close yet, so setting
+        // up on top of it would publish and subscribe on the way out.
+        if (stopping) {
+          client.close()
+
+          break
+        }
+
         try {
           await onConnected?.(client)
         } catch (error) {

--- a/packages/viewer-client/src/cli/session.ts
+++ b/packages/viewer-client/src/cli/session.ts
@@ -1,0 +1,140 @@
+import pc from "picocolors"
+import type { ViewerClient } from "../client.js"
+import type { Reporter } from "./output.js"
+
+const RECONNECT_BASE_MS = 1_000
+const RECONNECT_MAX_MS = 30_000
+
+export interface SessionOptions {
+  /** Opens a connection. Called again for each reconnect. */
+  connect: () => Promise<ViewerClient>
+  /**
+   * Subscribes and resolves whatever this session needs from the viewer.
+   *
+   * Runs on every connection, not just the first, since a viewer that
+   * restarted has forgotten what was published to the old one.
+   */
+  onConnected?: (client: ViewerClient) => Promise<void>
+  /** Reconnect with backoff rather than returning when the connection drops. */
+  follow: boolean
+  reporter: Reporter
+  /** Runs once on the way out, interrupted or not, before the process ends. */
+  onStop?: () => Promise<void> | void
+}
+
+/**
+ * Resolves when the connection drops, or when `interrupted` is called.
+ *
+ * Closing the connection ourselves does not reach `onClose`: `close()` marks
+ * the connection disposed before the transport reports back, and that is the
+ * check that stops listeners firing twice. So an interrupt has to end this
+ * wait directly rather than through the close it triggers.
+ */
+function untilClosed(client: ViewerClient, interrupted: (end: () => void) => void): Promise<void> {
+  return new Promise<void>((done) => {
+    interrupted(done)
+
+    client.connection.onClose(() => done())
+    client.connection.peer.on("session.disconnect", () => done())
+  })
+}
+
+/**
+ * Holds a viewer connection, reconnecting with backoff while it is asked to.
+ *
+ * Shared by `logs -f` and `connect`, which want the same loop for different
+ * reasons: one to keep a stream alive, the other to keep a session alive.
+ *
+ * Interrupting returns rather than calling `process.exit`, so a caller with
+ * buffered writes gets to flush them. A crash is exactly when a log file
+ * matters, and half a line in it is worse than none.
+ */
+export async function runSession({
+  connect,
+  onConnected,
+  follow,
+  reporter,
+  onStop,
+}: SessionOptions): Promise<void> {
+  let attempt = 0
+  let stopping = false
+  let current: ViewerClient | undefined
+  let wake: (() => void) | undefined
+
+  const interrupt = () => {
+    // A second ctrl-c means the first one did not get us out fast enough.
+    if (stopping) process.exit(130)
+
+    stopping = true
+    current?.close()
+    wake?.()
+  }
+
+  process.on("SIGINT", interrupt)
+
+  try {
+    // oxlint-disable-next-line no-unmodified-loop-condition -- set by the SIGINT handler above
+    while (!stopping) {
+      try {
+        const client = await connect()
+
+        current = client
+
+        try {
+          await onConnected?.(client)
+        } catch (error) {
+          // The socket is open from here on, and an open socket keeps the
+          // event loop alive, so a failed setup would hang rather than report.
+          client.close()
+
+          throw error
+        }
+
+        attempt = 0
+
+        await untilClosed(client, (end) => {
+          wake = end
+        })
+
+        wake = undefined
+
+        // A `session.disconnect` can arrive with the socket still open, so the
+        // old client goes before a replacement takes its place. Already-closed
+        // connections ignore this.
+        client.close()
+      } catch (error) {
+        if (!follow) throw error
+        if (stopping) break
+
+        reporter.note(pc.dim(`disconnected: ${error instanceof Error ? error.message : error}`))
+      }
+
+      if (!follow || stopping) break
+
+      // Back off so a viewer that is closed or restarting isn't hammered.
+      const delay = Math.min(RECONNECT_BASE_MS * 2 ** attempt++, RECONNECT_MAX_MS)
+
+      reporter.note(pc.dim(`reconnecting in ${Math.round(delay / 1000)}s`))
+
+      await new Promise<void>((done) => {
+        const timer = setTimeout(done, delay)
+
+        // Interrupting during the backoff should not wait it out.
+        wake = () => {
+          clearTimeout(timer)
+          done()
+        }
+      })
+
+      wake = undefined
+    }
+  } finally {
+    // Removed on the way out, or a caller that runs this more than once would
+    // stack a handler per call.
+    process.off("SIGINT", interrupt)
+
+    current?.close()
+
+    await onStop?.()
+  }
+}

--- a/packages/viewer-client/src/client.ts
+++ b/packages/viewer-client/src/client.ts
@@ -35,8 +35,8 @@ import type {
 /**
  * Typed calls and events over a `ViewerConnection`.
  *
- * The no-argument methods send `params: {}` rather than omitting `params` —
- * that is what the viewer's handlers expect.
+ * The no-argument methods send `params: {}` rather than omitting `params`,
+ * which is what the viewer's handlers expect.
  */
 export class ViewerClient {
   readonly connection: ViewerConnection

--- a/packages/viewer-client/src/compile-errors.test.ts
+++ b/packages/viewer-client/src/compile-errors.test.ts
@@ -87,7 +87,7 @@ describe("diagnosticsFrom", () => {
 describe("diagnosticsFrom on a viewer that sends rubbish", () => {
   it("keeps the row but replaces a message of uninitialised memory", () => {
     // Verbatim from YATPV Dev 26.3.0.0, answering a save whose Lua would not
-    // parse: the row is right, the message is 58 NUL bytes.
+    // parse. The row is right, the message is 58 NUL bytes.
     const response = {
       diagnostics: [{ row: 3, column: 0, level: "ERROR", message: "\u0000".repeat(58) }],
     }
@@ -100,6 +100,26 @@ describe("diagnosticsFrom on a viewer that sends rubbish", () => {
         message: "the viewer reported an error here but sent no message with it",
       },
     ])
+  })
+
+  it("replaces a message that arrived empty in the first place", () => {
+    const response = {
+      diagnostics: [{ row: 4, column: 0, level: "ERROR", message: "" }],
+    }
+
+    expect(diagnosticsFrom(response, "luau")[0]!.message).toBe(
+      "the viewer reported an error here but sent no message with it",
+    )
+  })
+
+  it("strips a colour escape whole rather than leaving its bracket behind", () => {
+    const response = {
+      diagnostics: [
+        { row: 2, column: 0, level: "ERROR", message: "\u001b[31mExpected identifier\u001b[0m" },
+      ],
+    }
+
+    expect(diagnosticsFrom(response, "luau")[0]!.message).toBe("Expected identifier")
   })
 
   it("strips control characters out of a message that still says something", () => {

--- a/packages/viewer-client/src/compile-errors.test.ts
+++ b/packages/viewer-client/src/compile-errors.test.ts
@@ -83,3 +83,40 @@ describe("diagnosticsFrom", () => {
     expect(diagnosticsFrom({ diagnostics: [], errors: ["a.luau:1: first"] }, "luau")).toEqual([])
   })
 })
+
+describe("diagnosticsFrom on a viewer that sends rubbish", () => {
+  it("keeps the row but replaces a message of uninitialised memory", () => {
+    // Verbatim from YATPV Dev 26.3.0.0, answering a save whose Lua would not
+    // parse: the row is right, the message is 58 NUL bytes.
+    const response = {
+      diagnostics: [{ row: 3, column: 0, level: "ERROR", message: "\u0000".repeat(58) }],
+    }
+
+    expect(diagnosticsFrom(response, "luau")).toEqual([
+      {
+        row: 3,
+        column: 0,
+        level: "ERROR",
+        message: "the viewer reported an error here but sent no message with it",
+      },
+    ])
+  })
+
+  it("strips control characters out of a message that still says something", () => {
+    const response = {
+      diagnostics: [
+        { row: 2, column: 0, level: "ERROR", message: "Expected identifier\u0000\u0007" },
+      ],
+    }
+
+    expect(diagnosticsFrom(response, "luau")[0]!.message).toBe("Expected identifier")
+  })
+
+  it("leaves an ordinary message exactly as it was", () => {
+    const response = {
+      diagnostics: [{ row: 2, column: 0, level: "ERROR", message: "Unknown global 'foo'" }],
+    }
+
+    expect(diagnosticsFrom(response, "luau")[0]!.message).toBe("Unknown global 'foo'")
+  })
+})

--- a/packages/viewer-client/src/compile-errors.ts
+++ b/packages/viewer-client/src/compile-errors.ts
@@ -62,5 +62,32 @@ export function diagnosticsFrom(
   response: Pick<ObjectContentSaveResponse, "diagnostics" | "errors"> | undefined,
   language: CompileLanguage,
 ): Diagnostic[] {
-  return response?.diagnostics ?? parseCompileErrors(response?.errors, language)
+  const diagnostics = response?.diagnostics ?? parseCompileErrors(response?.errors, language)
+
+  return diagnostics.map(readable)
+}
+
+/** Control characters, which a terminal renders as anything from nothing to a mess. */
+// oxlint-disable-next-line no-control-regex -- stripping them is the point
+const UNPRINTABLE = /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g
+
+/**
+ * A diagnostic fit to print.
+ *
+ * A viewer has been seen answering a failed compile with a message of nothing
+ * but NUL bytes, which is uninitialised memory rather than an error, and
+ * printing it puts 58 invisible characters through the terminal, the JSON
+ * output and the log file alike. The row it came with is still worth having,
+ * so the message is replaced rather than the diagnostic dropped.
+ */
+function readable(diagnostic: Diagnostic): Diagnostic {
+  const message = diagnostic.message.replaceAll(UNPRINTABLE, "").trim()
+
+  if (message === diagnostic.message) return diagnostic
+
+  return {
+    ...diagnostic,
+    message:
+      message === "" ? "the viewer reported an error here but sent no message with it" : message,
+  }
 }

--- a/packages/viewer-client/src/compile-errors.ts
+++ b/packages/viewer-client/src/compile-errors.ts
@@ -67,27 +67,36 @@ export function diagnosticsFrom(
   return diagnostics.map(readable)
 }
 
+/**
+ * ANSI escape sequences, matched whole.
+ *
+ * Stripped before the control characters below, or removing the escape on its
+ * own would leave the `[31m` behind as literal text.
+ */
+// oxlint-disable-next-line no-control-regex -- matching the escape is the point
+const ANSI = /\u001b\[[0-9;?]*[ -/]*[@-~]|\u001b[@-Z\\-_]/g
+
 /** Control characters, which a terminal renders as anything from nothing to a mess. */
 // oxlint-disable-next-line no-control-regex -- stripping them is the point
 const UNPRINTABLE = /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g
 
+const NO_MESSAGE = "the viewer reported an error here but sent no message with it"
+
 /**
  * A diagnostic fit to print.
  *
- * A viewer has been seen answering a failed compile with a message of nothing
- * but NUL bytes, which is uninitialised memory rather than an error, and
- * printing it puts 58 invisible characters through the terminal, the JSON
- * output and the log file alike. The row it came with is still worth having,
- * so the message is replaced rather than the diagnostic dropped.
+ * A viewer has been seen answering a failed compile with 58 NUL bytes, which
+ * is uninitialised memory rather than an error, and printing it puts 58
+ * invisible characters through the terminal, the JSON output and the log file.
+ * The row is still worth having, so the message is replaced rather than the
+ * diagnostic dropped.
  */
 function readable(diagnostic: Diagnostic): Diagnostic {
-  const message = diagnostic.message.replaceAll(UNPRINTABLE, "").trim()
+  const message = diagnostic.message.replaceAll(ANSI, "").replaceAll(UNPRINTABLE, "").trim()
 
-  if (message === diagnostic.message) return diagnostic
+  // Only a message that survived untouched is already fit to print. One that
+  // arrived empty needs the fallback just as much as one emptied here.
+  if (message === diagnostic.message && message !== "") return diagnostic
 
-  return {
-    ...diagnostic,
-    message:
-      message === "" ? "the viewer reported an error here but sent no message with it" : message,
-  }
+  return { ...diagnostic, message: message === "" ? NO_MESSAGE : message }
 }

--- a/packages/viewer-client/src/control/client.ts
+++ b/packages/viewer-client/src/control/client.ts
@@ -8,7 +8,6 @@ import { controlPath, socketTransport } from "./socket.js"
 
 const CONNECT_TIMEOUT_MS = 5_000
 
-/** What a control client sees of the session it attached to. */
 export interface ControlStatus {
   connected: boolean
   watching: boolean

--- a/packages/viewer-client/src/control/client.ts
+++ b/packages/viewer-client/src/control/client.ts
@@ -1,0 +1,126 @@
+import { connect as connectSocket } from "node:net"
+import { ViewerClient } from "../client.js"
+import { ViewerUnavailableError } from "../protocol/errors.js"
+import type { Transport } from "../protocol/jsonrpc.js"
+import { type ConnectOptions, ViewerConnection } from "../protocol/peer.js"
+import { readSession, type SessionInfo } from "../state.js"
+import { controlPath, socketTransport } from "./socket.js"
+
+const CONNECT_TIMEOUT_MS = 5_000
+
+/** What a control client sees of the session it attached to. */
+export interface ControlStatus {
+  connected: boolean
+  watching: boolean
+  pushing: boolean
+  cursor: number
+  targets: {
+    name: string
+    file: string
+    item?: string
+    lastPush?: Record<string, unknown>
+  }[]
+}
+
+export interface WaitResult {
+  settled: boolean
+  cursor: number
+  targets: Record<string, unknown>[]
+  logs: Record<string, unknown>[]
+  /** Records the cap left out. They are all in `.slua/logs.jsonl`. */
+  truncated: number
+  logPath?: string
+}
+
+/**
+ * A `ViewerClient` attached to a running `connect`, plus the `control.*` calls.
+ *
+ * The session speaks the viewer's own protocol, so this is the same client
+ * class over a different transport, and every existing command works against
+ * it unchanged.
+ */
+export class ControlClient extends ViewerClient {
+  status(): Promise<ControlStatus> {
+    return this.connection.peer.call("control.status", {})
+  }
+
+  logs(params: { since?: number; sinceMs?: number; limit?: number } = {}): Promise<{
+    cursor: number
+    logs: Record<string, unknown>[]
+    truncated: number
+    logPath?: string
+  }> {
+    return this.connection.peer.call("control.logs", params)
+  }
+
+  /**
+   * Pushes now, skipping the debounce, and returns the cursor to wait from.
+   *
+   * The cursor comes back from before the push starts, so handing it straight
+   * to `wait` cannot match the previous run's results.
+   */
+  pushNow(targets?: string[]): Promise<{ cursor: number; waited: number; targets: string[] }> {
+    return this.connection.peer.call("control.push", { targets })
+  }
+
+  /** Blocks until a push newer than `since` has settled, or the timeout. */
+  wait(params: { since?: number; timeoutMs?: number } = {}): Promise<WaitResult> {
+    // The call has to outlive the block it is asking for, or the transport
+    // times out before the answer it was waiting for can arrive.
+    return this.connection.peer.call("control.wait", params, (params.timeoutMs ?? 30_000) + 10_000)
+  }
+}
+
+/** Opens a socket to a path, or reports it as unavailable. */
+function pathTransport(path: string): () => Promise<Transport> {
+  return () =>
+    new Promise<Transport>((ready, failed) => {
+      const socket = connectSocket(path)
+
+      const timer = setTimeout(() => {
+        socket.destroy()
+        failed(new ViewerUnavailableError(path, `no response within ${CONNECT_TIMEOUT_MS}ms`))
+      }, CONNECT_TIMEOUT_MS)
+
+      socket.once("connect", () => {
+        clearTimeout(timer)
+        ready(socketTransport(socket))
+      })
+
+      socket.once("error", (error) => {
+        clearTimeout(timer)
+        failed(new ViewerUnavailableError(path, error.message))
+      })
+    })
+}
+
+export interface AttachOptions extends Pick<ConnectOptions, "timeoutMs" | "clientName"> {
+  /** The socket to use instead of the one derived from the project root. */
+  path?: string
+}
+
+/**
+ * Attaches to a running session, or reports why it could not.
+ *
+ * Liveness is decided by connecting, never by the session file existing: a pid
+ * file outlives the process that wrote it, and the socket does not lie.
+ */
+export async function attachControl(
+  root: string,
+  options: AttachOptions = {},
+): Promise<ControlClient> {
+  const session = await readSession(root)
+  const path = options.path ?? session?.socket ?? controlPath(root)
+
+  const connection = await ViewerConnection.connect({
+    ...options,
+    transport: pathTransport(path),
+  })
+
+  return new ControlClient(connection)
+}
+
+/** The session recorded for a project, whether or not it is still running. */
+export async function sessionFor(root: string): Promise<SessionInfo | undefined> {
+  return await readSession(root)
+}

--- a/packages/viewer-client/src/control/control.test.ts
+++ b/packages/viewer-client/src/control/control.test.ts
@@ -143,6 +143,34 @@ describe("the control socket", () => {
     expect(seen).toEqual(["hello"])
   })
 
+  it("serves nothing before the challenge is answered", async () => {
+    const { server, recorded } = await session()
+
+    const rogue = connectSocket(server.path)
+    const lines: string[] = []
+
+    rogue.setEncoding("utf8")
+    rogue.on("data", (chunk: string) => lines.push(chunk))
+
+    await new Promise((done) => setTimeout(done, 100))
+
+    // Asked without ever answering the handshake the session just sent.
+    rogue.write(`${JSON.stringify({ jsonrpc: "2.0", id: 1, method: "control.status" })}\n`)
+    rogue.write(`${JSON.stringify({ jsonrpc: "2.0", id: 2, method: "object.list" })}\n`)
+
+    await new Promise((done) => setTimeout(done, 100))
+
+    const seen = lines.join("")
+
+    // Method not found, rather than the session's state or a call the viewer
+    // would have run on this caller's behalf.
+    expect(seen).not.toContain('"cursor":7')
+    expect(recorded.forwarded).toEqual([])
+    expect(seen).toContain("-32601")
+
+    rogue.destroy()
+  })
+
   it("refuses a client that cannot answer the challenge", async () => {
     const { server } = await session()
 

--- a/packages/viewer-client/src/control/control.test.ts
+++ b/packages/viewer-client/src/control/control.test.ts
@@ -1,0 +1,172 @@
+import { afterEach, describe, expect, it } from "bun:test"
+import { mkdtemp, rm } from "node:fs/promises"
+import { connect as connectSocket } from "node:net"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import type { SessionHandshake } from "../protocol/types.js"
+import { attachControl, type ControlClient } from "./client"
+import { type ControlServer, startControlServer } from "./server"
+
+const roots: string[] = []
+const servers: ControlServer[] = []
+const clients: ControlClient[] = []
+
+afterEach(async () => {
+  for (const client of clients.splice(0)) client.close()
+  for (const server of servers.splice(0)) await server.close()
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true })
+})
+
+/** What the viewer would have said, as the session reports it onwards. */
+const HANDSHAKE: SessionHandshake = {
+  serverVersion: "1.0.0",
+  protocolVersion: "1.0",
+  viewerName: "Mock Viewer",
+  viewerVersion: "0.0.0",
+  agentId: "dddddddd-1111-2222-3333-444444444444",
+  agentName: "mock.resident",
+  languages: ["lsl", "luau"],
+  features: { liveSync: true, compilation: true, unifiedDiagnostics: true },
+} as SessionHandshake
+
+interface Recorded {
+  forwarded: { method: string; params: unknown }[]
+  pushed: (string[] | undefined)[]
+}
+
+async function session(overrides: Partial<Parameters<typeof startControlServer>[1]> = {}) {
+  const root = await mkdtemp(join(tmpdir(), "slua-control-"))
+
+  roots.push(root)
+
+  const recorded: Recorded = { forwarded: [], pushed: [] }
+
+  const server = await startControlServer(root, {
+    handshake: () => HANDSHAKE,
+    status: () => ({ connected: true, watching: true, pushing: false, cursor: 7, targets: [] }),
+    logs: ({ since = 0 }) => ({
+      cursor: 9,
+      logs: [{ seq: 9, level: "debug", message: "after" }].filter((entry) => entry.seq > since),
+      truncated: 0,
+    }),
+    push: async ({ targets }) => {
+      recorded.pushed.push(targets)
+
+      return { cursor: 5, targets: targets ?? ["main"] }
+    },
+    wait: async ({ since = 0 }) => ({
+      settled: true,
+      cursor: 12,
+      targets: [{ name: "main", ok: true }],
+      logs: [{ seq: since + 1, level: "debug", message: "settled" }],
+      truncated: 0,
+    }),
+    forward: async (method, params) => {
+      recorded.forwarded.push({ method, params })
+
+      return { objects: [] }
+    },
+    ...overrides,
+  })
+
+  servers.push(server)
+
+  const client = await attachControl(root, { path: server.path })
+
+  clients.push(client)
+
+  return { root, server, client, recorded }
+}
+
+describe("the control socket", () => {
+  it("hands a plain ViewerClient the viewer's own handshake", async () => {
+    const { client } = await session()
+
+    // The `unifiedDiagnostics` checks in the runtime view read this, so a
+    // session that reported its own features would change how output is
+    // filtered for every client attached to it.
+    expect(client.connection.handshake?.viewerName).toBe("Mock Viewer")
+    expect(client.connection.handshake?.features.unifiedDiagnostics).toBe(true)
+  })
+
+  it("forwards a viewer call upstream, unchanged", async () => {
+    const { client, recorded } = await session()
+
+    await client.objectList()
+
+    expect(recorded.forwarded).toEqual([{ method: "object.list", params: {} }])
+  })
+
+  it("answers the control namespace", async () => {
+    const { client } = await session()
+
+    expect(await client.status()).toMatchObject({ connected: true, cursor: 7 })
+    expect(await client.logs({ since: 5 })).toMatchObject({ cursor: 9, truncated: 0 })
+  })
+
+  it("hands back a cursor from before the push it triggers", async () => {
+    const { client, recorded } = await session()
+
+    const result = await client.pushNow(["main"])
+
+    expect(recorded.pushed).toEqual([["main"]])
+
+    // Waiting from this cursor has to match the push it just asked for, not
+    // the one before it, which is why it comes from before the trigger.
+    const settled = await client.wait({ since: result.cursor })
+
+    expect(settled).toMatchObject({ settled: true, targets: [{ name: "main", ok: true }] })
+    expect(settled.logs).toEqual([expect.objectContaining({ seq: result.cursor + 1 })])
+  })
+
+  it("broadcasts viewer notifications to every attached client", async () => {
+    const { root, server } = await session()
+    const second = await attachControl(root, { path: server.path })
+
+    clients.push(second)
+
+    const seen: string[] = []
+
+    second.on("runtime.debug", (params) => seen.push(params.message))
+
+    server.broadcast("runtime.debug", {
+      scriptId: "",
+      objectId: "id",
+      objectName: "Object",
+      message: "hello",
+    })
+
+    // The notification crosses a process boundary in real use, so give it a
+    // turn of the loop to arrive.
+    await new Promise((done) => setTimeout(done, 50))
+
+    expect(seen).toEqual(["hello"])
+  })
+
+  it("refuses a client that cannot answer the challenge", async () => {
+    const { server } = await session()
+
+    // A process that never reads the challenge file is what anything other
+    // than a real client on this socket looks like.
+    const rogue = connectSocket(server.path)
+    const lines: string[] = []
+
+    rogue.setEncoding("utf8")
+    rogue.on("data", (chunk: string) => lines.push(chunk))
+
+    await new Promise((done) => setTimeout(done, 100))
+
+    // The session drives the handshake, exactly as the viewer does.
+    expect(lines.join("")).toContain("session.handshake")
+
+    rogue.write(
+      `${JSON.stringify({ jsonrpc: "2.0", id: 1, result: { challenge_response: "no" } })}\n`,
+    )
+
+    await new Promise((done) => setTimeout(done, 100))
+
+    expect(lines.join("")).toContain("Invalid challenge response")
+
+    rogue.destroy()
+  })
+})

--- a/packages/viewer-client/src/control/control.test.ts
+++ b/packages/viewer-client/src/control/control.test.ts
@@ -1,11 +1,12 @@
 import { afterEach, describe, expect, it } from "bun:test"
-import { mkdtemp, rm } from "node:fs/promises"
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
 import { connect as connectSocket } from "node:net"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import type { SessionHandshake } from "../protocol/types.js"
 import { attachControl, type ControlClient } from "./client"
-import { type ControlServer, startControlServer } from "./server"
+import { controlPath } from "./socket"
+import { type ControlServer, SessionAlreadyRunningError, startControlServer } from "./server"
 
 const roots: string[] = []
 const servers: ControlServer[] = []
@@ -34,14 +35,11 @@ interface Recorded {
   pushed: (string[] | undefined)[]
 }
 
-async function session(overrides: Partial<Parameters<typeof startControlServer>[1]> = {}) {
-  const root = await mkdtemp(join(tmpdir(), "slua-control-"))
-
-  roots.push(root)
-
-  const recorded: Recorded = { forwarded: [], pushed: [] }
-
-  const server = await startControlServer(root, {
+/** The session a control client sees, with nothing behind it but this file. */
+function handlers(
+  recorded: Recorded = { forwarded: [], pushed: [] },
+): Parameters<typeof startControlServer>[1] {
+  return {
     handshake: () => HANDSHAKE,
     status: () => ({ connected: true, watching: true, pushing: false, cursor: 7, targets: [] }),
     logs: ({ since = 0 }) => ({
@@ -66,8 +64,17 @@ async function session(overrides: Partial<Parameters<typeof startControlServer>[
 
       return { objects: [] }
     },
-    ...overrides,
-  })
+  }
+}
+
+async function session(overrides: Partial<Parameters<typeof startControlServer>[1]> = {}) {
+  const root = await mkdtemp(join(tmpdir(), "slua-control-"))
+
+  roots.push(root)
+
+  const recorded: Recorded = { forwarded: [], pushed: [] }
+
+  const server = await startControlServer(root, { ...handlers(recorded), ...overrides })
 
   servers.push(server)
 
@@ -169,6 +176,64 @@ describe("the control socket", () => {
     expect(seen).toContain("-32601")
 
     rogue.destroy()
+  })
+
+  it("lets only one of two concurrent starts own the project", async () => {
+    const root = await mkdtemp(join(tmpdir(), "slua-control-"))
+
+    roots.push(root)
+
+    // Both find nothing listening, which is the moment a probe-then-unlink
+    // start deletes the socket the other one just bound.
+    const starts = await Promise.allSettled([
+      startControlServer(root, handlers()),
+      startControlServer(root, handlers()),
+    ])
+
+    for (const start of starts) {
+      if (start.status === "fulfilled") servers.push(start.value)
+    }
+
+    const bound = starts.filter((start) => start.status === "fulfilled")
+    const refused = starts.find((start) => start.status === "rejected")
+
+    expect(bound.length).toBe(1)
+    expect(refused?.reason).toBeInstanceOf(SessionAlreadyRunningError)
+
+    // Reachable, rather than listening on a socket the loser unlinked away.
+    const client = await attachControl(root, { path: controlPath(root) })
+
+    clients.push(client)
+
+    expect(await client.status()).toMatchObject({ cursor: 7 })
+  })
+
+  it("takes over a socket a crashed session left behind", async () => {
+    const root = await mkdtemp(join(tmpdir(), "slua-control-"))
+
+    roots.push(root)
+
+    // What a SIGKILLed session leaves behind, refusing the bind and answering
+    // nothing.
+    await writeFile(controlPath(root), "", "utf8")
+
+    const server = await startControlServer(root, handlers())
+
+    servers.push(server)
+
+    const client = await attachControl(root, { path: server.path })
+
+    clients.push(client)
+
+    expect(await client.status()).toMatchObject({ cursor: 7 })
+  })
+
+  it("refuses a second session while the first is listening", async () => {
+    const { root } = await session()
+
+    await expect(startControlServer(root, handlers())).rejects.toBeInstanceOf(
+      SessionAlreadyRunningError,
+    )
   })
 
   it("refuses a client that cannot answer the challenge", async () => {

--- a/packages/viewer-client/src/control/control.test.ts
+++ b/packages/viewer-client/src/control/control.test.ts
@@ -208,25 +208,29 @@ describe("the control socket", () => {
     expect(await client.status()).toMatchObject({ cursor: 7 })
   })
 
-  it("takes over a socket a crashed session left behind", async () => {
-    const root = await mkdtemp(join(tmpdir(), "slua-control-"))
+  // A named pipe is not a file, so there is no leftover to write on Windows.
+  it.skipIf(process.platform === "win32")(
+    "takes over a socket a crashed session left behind",
+    async () => {
+      const root = await mkdtemp(join(tmpdir(), "slua-control-"))
 
-    roots.push(root)
+      roots.push(root)
 
-    // What a SIGKILLed session leaves behind, refusing the bind and answering
-    // nothing.
-    await writeFile(controlPath(root), "", "utf8")
+      // What a SIGKILLed session leaves behind, refusing the bind and answering
+      // nothing.
+      await writeFile(controlPath(root), "", "utf8")
 
-    const server = await startControlServer(root, handlers())
+      const server = await startControlServer(root, handlers())
 
-    servers.push(server)
+      servers.push(server)
 
-    const client = await attachControl(root, { path: server.path })
+      const client = await attachControl(root, { path: server.path })
 
-    clients.push(client)
+      clients.push(client)
 
-    expect(await client.status()).toMatchObject({ cursor: 7 })
-  })
+      expect(await client.status()).toMatchObject({ cursor: 7 })
+    },
+  )
 
   it("refuses a second session while the first is listening", async () => {
     const { root } = await session()

--- a/packages/viewer-client/src/control/server.ts
+++ b/packages/viewer-client/src/control/server.ts
@@ -245,6 +245,8 @@ export async function startControlServer(
   // pipes on Windows are not files, so there is nothing to chmod there.
   if (process.platform !== "win32") await chmod(path, 0o600).catch(() => {})
 
+  const bound = await identity(path)
+
   return {
     path,
 
@@ -268,7 +270,10 @@ export async function startControlServer(
       peers.clear()
 
       await new Promise<void>((done) => server.close(() => done()))
-      await unlink(path).catch(() => {})
+
+      // Only while the path is still the socket this session bound. A session
+      // that took the project over in the meantime owns what is there now.
+      if ((await identity(path)) === bound) await unlink(path).catch(() => {})
     },
   }
 }

--- a/packages/viewer-client/src/control/server.ts
+++ b/packages/viewer-client/src/control/server.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto"
 import { chmod, mkdtemp, rm, unlink, writeFile } from "node:fs/promises"
-import { createServer, type Server, type Socket } from "node:net"
+import { connect, createServer, type Server, type Socket } from "node:net"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { JsonRpcPeer } from "../protocol/jsonrpc.js"
@@ -10,9 +10,9 @@ import { controlPath, socketTransport } from "./socket.js"
 /**
  * The viewer calls a control client may make through the session.
  *
- * Listed rather than pattern-matched, because a handler is registered per
- * method and a client asking for anything else deserves the protocol's own
- * "method not found" rather than a forwarded surprise.
+ * Listed rather than pattern-matched. A handler is registered per method, and
+ * a client asking for anything else deserves the protocol's own "method not
+ * found" rather than a forwarded surprise.
  */
 export const FORWARDED_METHODS = [
   "object.list",
@@ -36,7 +36,18 @@ export const FORWARDED_METHODS = [
   "command.list",
 ]
 
-/** Everything a running session offers over the socket. */
+/** How long a leftover socket has to answer before it counts as alive. */
+const LIVENESS_TIMEOUT_MS = 500
+
+/** Raised when the project already has a session listening on its socket. */
+export class SessionAlreadyRunningError extends Error {
+  constructor(readonly path: string) {
+    super(`a session is already running for this project; its control socket is ${path}`)
+
+    this.name = "SessionAlreadyRunningError"
+  }
+}
+
 export interface ControlHandlers {
   /** The viewer's own handshake, so a client sees the real feature set. */
   handshake(): SessionHandshake | undefined
@@ -44,25 +55,49 @@ export interface ControlHandlers {
   logs(params: { since?: number; sinceMs?: number; limit?: number }): unknown
   push(params: { targets?: string[] }): Promise<unknown>
   wait(params: { since?: number; timeoutMs?: number }): Promise<unknown>
-  /** Passes a call through to the viewer. */
   forward(method: string, params: unknown): Promise<unknown>
 }
 
 export interface ControlServer {
   readonly path: string
-  /** Sends a viewer notification on to every attached client. */
+  /** Passes a viewer notification on to every attached client. */
   broadcast(method: string, params: unknown): void
   readonly clients: number
   close(): Promise<void>
+}
+
+/** Whether something is listening on `path` right now. */
+function answering(path: string): Promise<boolean> {
+  return new Promise<boolean>((done) => {
+    const socket = connect(path)
+
+    const settle = (live: boolean) => {
+      socket.destroy()
+      done(live)
+    }
+
+    // A socket that connects but never speaks is still one somebody owns, so
+    // the timeout answers yes.
+    const timer = setTimeout(() => settle(true), LIVENESS_TIMEOUT_MS)
+
+    socket.once("connect", () => {
+      clearTimeout(timer)
+      settle(true)
+    })
+
+    socket.once("error", () => {
+      clearTimeout(timer)
+      settle(false)
+    })
+  })
 }
 
 /**
  * The auth challenge, the way the viewer does it.
  *
  * A unix socket at mode 0600 is already only reachable by this user, so this
- * is not what makes the socket safe. It is here because it is what makes
- * `ViewerClient` connect to a session with no changes at all: the client
- * answers the same handshake it answers for the viewer.
+ * is not what keeps it safe. It is here so `ViewerClient` attaches to a
+ * session unchanged, answering the same handshake it answers for the viewer.
  */
 async function challenge(): Promise<{ path: string; value: string; clean: () => Promise<void> }> {
   const directory = await mkdtemp(join(tmpdir(), "slua-control-"))
@@ -92,8 +127,11 @@ export async function startControlServer(
   const path = controlPath(root)
   const peers = new Set<JsonRpcPeer>()
 
-  // A socket left behind by a session that crashed would refuse the bind, and
-  // the liveness question is settled by connecting, not by the file existing.
+  // A socket left behind by a crashed session would refuse the bind, and only
+  // connecting settles whether one is live. Unlinking a socket that still
+  // answers would strand the session behind it with its clients attached.
+  if (await answering(path)) throw new SessionAlreadyRunningError(path)
+
   await unlink(path).catch(() => {})
 
   const serve = async (socket: Socket) => {
@@ -109,26 +147,17 @@ export async function startControlServer(
 
     peer.on("session.disconnect", () => peer.close())
 
-    peer.handle("control.status", () => handlers.status())
-    peer.handle("control.logs", (params) => handlers.logs(params ?? {}))
-    peer.handle("control.push", (params) => handlers.push(params ?? {}))
-    peer.handle("control.wait", (params) => handlers.wait(params ?? {}))
-
-    // Anything else the client knows how to say to a viewer, the session says
-    // on its behalf. Ids are remapped for free: this is a fresh call upstream.
-    for (const method of FORWARDED_METHODS) {
-      peer.handle(method, (params) => handlers.forward(method, params))
-    }
-
-    const auth = await challenge()
+    let auth: Awaited<ReturnType<typeof challenge>> | undefined
 
     try {
+      auth = await challenge()
+
       const upstream = handlers.handshake()
 
       const response = await peer.call<SessionHandshakeResponse>("session.handshake", {
         ...upstream,
         // The viewer's own challenge file is long gone, and echoing a path we
-        // do not own would be nonsense; this one is ours.
+        // do not own would be nonsense. This one is ours.
         challenge: auth.path,
         serverVersion: upstream?.serverVersion ?? "1.0.0",
         protocolVersion: upstream?.protocolVersion ?? "1.0",
@@ -147,7 +176,20 @@ export async function startControlServer(
 
       return
     } finally {
-      await auth.clean()
+      await auth?.clean()
+    }
+
+    // Registered only now. Everything below reaches the viewer or this
+    // session's own state, and an unauthenticated caller reaches neither.
+    peer.handle("control.status", () => handlers.status())
+    peer.handle("control.logs", (params) => handlers.logs(params ?? {}))
+    peer.handle("control.push", (params) => handlers.push(params ?? {}))
+    peer.handle("control.wait", (params) => handlers.wait(params ?? {}))
+
+    // Anything else the client knows how to say to a viewer, the session says
+    // on its behalf. Ids remap for free, since this is a fresh call upstream.
+    for (const method of FORWARDED_METHODS) {
+      peer.handle(method, (params) => handlers.forward(method, params))
     }
 
     peer.notify("session.ok", {})

--- a/packages/viewer-client/src/control/server.ts
+++ b/packages/viewer-client/src/control/server.ts
@@ -93,7 +93,11 @@ function answering(path: string): Promise<boolean> {
 }
 
 function inUse(error: unknown): boolean {
-  return (error as NodeJS.ErrnoException | undefined)?.code === "EADDRINUSE"
+  const code = (error as NodeJS.ErrnoException | undefined)?.code
+
+  // Node says the address is taken; bun says the path already exists, which is
+  // the same refusal and the only one either of them gives for a live session.
+  return code === "EADDRINUSE" || code === "EEXIST"
 }
 
 /** Names the socket file, so a start cannot unlink one it never looked at. */

--- a/packages/viewer-client/src/control/server.ts
+++ b/packages/viewer-client/src/control/server.ts
@@ -1,0 +1,198 @@
+import { randomUUID } from "node:crypto"
+import { chmod, mkdtemp, rm, unlink, writeFile } from "node:fs/promises"
+import { createServer, type Server, type Socket } from "node:net"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { JsonRpcPeer } from "../protocol/jsonrpc.js"
+import type { SessionHandshake, SessionHandshakeResponse } from "../protocol/types.js"
+import { controlPath, socketTransport } from "./socket.js"
+
+/**
+ * The viewer calls a control client may make through the session.
+ *
+ * Listed rather than pattern-matched, because a handler is registered per
+ * method and a client asking for anything else deserves the protocol's own
+ * "method not found" rather than a forwarded surprise.
+ */
+export const FORWARDED_METHODS = [
+  "object.list",
+  "object.request",
+  "object.unpublish",
+  "object.modify",
+  "object.content.get",
+  "object.content.save",
+  "object.item.create",
+  "object.item.delete",
+  "object.item.modify",
+  "object.script.set_running",
+  "object.script.reset",
+  "script.list",
+  "script.subscribe",
+  "language.syntax.id",
+  "language.syntax",
+  "language.syntax.cache",
+  "language.syntax.get",
+  "command.execute",
+  "command.list",
+]
+
+/** Everything a running session offers over the socket. */
+export interface ControlHandlers {
+  /** The viewer's own handshake, so a client sees the real feature set. */
+  handshake(): SessionHandshake | undefined
+  status(): unknown
+  logs(params: { since?: number; sinceMs?: number; limit?: number }): unknown
+  push(params: { targets?: string[] }): Promise<unknown>
+  wait(params: { since?: number; timeoutMs?: number }): Promise<unknown>
+  /** Passes a call through to the viewer. */
+  forward(method: string, params: unknown): Promise<unknown>
+}
+
+export interface ControlServer {
+  readonly path: string
+  /** Sends a viewer notification on to every attached client. */
+  broadcast(method: string, params: unknown): void
+  readonly clients: number
+  close(): Promise<void>
+}
+
+/**
+ * The auth challenge, the way the viewer does it.
+ *
+ * A unix socket at mode 0600 is already only reachable by this user, so this
+ * is not what makes the socket safe. It is here because it is what makes
+ * `ViewerClient` connect to a session with no changes at all: the client
+ * answers the same handshake it answers for the viewer.
+ */
+async function challenge(): Promise<{ path: string; value: string; clean: () => Promise<void> }> {
+  const directory = await mkdtemp(join(tmpdir(), "slua-control-"))
+  const value = randomUUID()
+  const path = join(directory, `sl_script_challenge_${randomUUID()}.tmp`)
+
+  await writeFile(path, value, { encoding: "utf8", mode: 0o600 })
+
+  return {
+    path,
+    value,
+    clean: () => rm(directory, { recursive: true, force: true }),
+  }
+}
+
+/**
+ * Serves the control socket for a running `connect`.
+ *
+ * It speaks the viewer's own JSON-RPC, so `control.*` is the only namespace
+ * it adds. Everything else a client already knows how to say is forwarded
+ * upstream, and every viewer notification is passed back down.
+ */
+export async function startControlServer(
+  root: string,
+  handlers: ControlHandlers,
+): Promise<ControlServer> {
+  const path = controlPath(root)
+  const peers = new Set<JsonRpcPeer>()
+
+  // A socket left behind by a session that crashed would refuse the bind, and
+  // the liveness question is settled by connecting, not by the file existing.
+  await unlink(path).catch(() => {})
+
+  const serve = async (socket: Socket) => {
+    const peer = new JsonRpcPeer(socketTransport(socket))
+
+    peers.add(peer)
+    peer.onClose(() => peers.delete(peer))
+
+    peer.handle("session.ping", (params?: { timestamp?: number }) => ({
+      timestamp: params?.timestamp ?? 0,
+      serverTime: Date.now(),
+    }))
+
+    peer.on("session.disconnect", () => peer.close())
+
+    peer.handle("control.status", () => handlers.status())
+    peer.handle("control.logs", (params) => handlers.logs(params ?? {}))
+    peer.handle("control.push", (params) => handlers.push(params ?? {}))
+    peer.handle("control.wait", (params) => handlers.wait(params ?? {}))
+
+    // Anything else the client knows how to say to a viewer, the session says
+    // on its behalf. Ids are remapped for free: this is a fresh call upstream.
+    for (const method of FORWARDED_METHODS) {
+      peer.handle(method, (params) => handlers.forward(method, params))
+    }
+
+    const auth = await challenge()
+
+    try {
+      const upstream = handlers.handshake()
+
+      const response = await peer.call<SessionHandshakeResponse>("session.handshake", {
+        ...upstream,
+        // The viewer's own challenge file is long gone, and echoing a path we
+        // do not own would be nonsense; this one is ours.
+        challenge: auth.path,
+        serverVersion: upstream?.serverVersion ?? "1.0.0",
+        protocolVersion: upstream?.protocolVersion ?? "1.0",
+        viewerName: upstream?.viewerName ?? "slua-viewer connect",
+      })
+
+      if (response?.challengeResponse !== auth.value) {
+        peer.notify("session.disconnect", { reason: 2, message: "Invalid challenge response" })
+        peer.close()
+
+        return
+      }
+    } catch {
+      // A client that cannot complete the handshake is not one we can serve.
+      peer.close()
+
+      return
+    } finally {
+      await auth.clean()
+    }
+
+    peer.notify("session.ok", {})
+  }
+
+  const server: Server = createServer((socket: Socket) => {
+    void serve(socket)
+  })
+
+  await new Promise<void>((ready, failed) => {
+    server.once("error", failed)
+    server.listen(path, () => {
+      server.off("error", failed)
+      ready()
+    })
+  })
+
+  // Only this user, which is what actually keeps the socket private. Named
+  // pipes on Windows are not files, so there is nothing to chmod there.
+  if (process.platform !== "win32") await chmod(path, 0o600).catch(() => {})
+
+  return {
+    path,
+
+    get clients() {
+      return peers.size
+    },
+
+    broadcast(method, params) {
+      for (const peer of peers) {
+        try {
+          peer.notify(method, params)
+        } catch {
+          // A client that went away mid-broadcast is not the session's problem.
+        }
+      }
+    },
+
+    async close() {
+      for (const peer of peers) peer.close()
+
+      peers.clear()
+
+      await new Promise<void>((done) => server.close(() => done()))
+      await unlink(path).catch(() => {})
+    },
+  }
+}

--- a/packages/viewer-client/src/control/server.ts
+++ b/packages/viewer-client/src/control/server.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto"
-import { chmod, mkdtemp, rm, unlink, writeFile } from "node:fs/promises"
+import { chmod, mkdtemp, rm, stat, unlink, writeFile } from "node:fs/promises"
 import { connect, createServer, type Server, type Socket } from "node:net"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
@@ -92,6 +92,17 @@ function answering(path: string): Promise<boolean> {
   })
 }
 
+function inUse(error: unknown): boolean {
+  return (error as NodeJS.ErrnoException | undefined)?.code === "EADDRINUSE"
+}
+
+/** Names the socket file, so a start cannot unlink one it never looked at. */
+async function identity(path: string): Promise<string | undefined> {
+  const stats = await stat(path).catch(() => undefined)
+
+  return stats && `${stats.dev}:${stats.ino}`
+}
+
 /**
  * The auth challenge, the way the viewer does it.
  *
@@ -126,13 +137,6 @@ export async function startControlServer(
 ): Promise<ControlServer> {
   const path = controlPath(root)
   const peers = new Set<JsonRpcPeer>()
-
-  // A socket left behind by a crashed session would refuse the bind, and only
-  // connecting settles whether one is live. Unlinking a socket that still
-  // answers would strand the session behind it with its clients attached.
-  if (await answering(path)) throw new SessionAlreadyRunningError(path)
-
-  await unlink(path).catch(() => {})
 
   const serve = async (socket: Socket) => {
     const peer = new JsonRpcPeer(socketTransport(socket))
@@ -199,13 +203,43 @@ export async function startControlServer(
     void serve(socket)
   })
 
-  await new Promise<void>((ready, failed) => {
-    server.once("error", failed)
-    server.listen(path, () => {
-      server.off("error", failed)
-      ready()
+  const listen = () =>
+    new Promise<void>((ready, failed) => {
+      server.once("error", failed)
+      server.listen(path, () => {
+        server.off("error", failed)
+        ready()
+      })
     })
-  })
+
+  // Binding is what settles who owns the project. Probing first and unlinking
+  // after leaves a window where two starts both find nothing there, and the
+  // loser deletes the winner's socket.
+  try {
+    await listen()
+  } catch (error) {
+    if (!inUse(error)) throw error
+
+    // Only connecting settles whether the socket that refused the bind is
+    // live. Unlinking one that still answers would strand the session behind
+    // it with its clients attached.
+    const refused = await identity(path)
+
+    if (await answering(path)) throw new SessionAlreadyRunningError(path)
+
+    // Another start may have cleaned the same corpse up while we were asking.
+    // Its socket is live, and not ours to remove.
+    if ((await identity(path)) === refused) await unlink(path).catch(() => {})
+
+    try {
+      await listen()
+    } catch (retry) {
+      if (!inUse(retry)) throw retry
+
+      // Somebody bound it between the unlink and here; the project is theirs.
+      throw new SessionAlreadyRunningError(path)
+    }
+  }
 
   // Only this user, which is what actually keeps the socket private. Named
   // pipes on Windows are not files, so there is nothing to chmod there.

--- a/packages/viewer-client/src/control/socket.ts
+++ b/packages/viewer-client/src/control/socket.ts
@@ -13,7 +13,14 @@ import type { Transport } from "../protocol/jsonrpc.js"
  * still only has to read one file to find it.
  */
 export function controlPath(root: string): string {
-  const key = createHash("sha1").update(resolve(root)).digest("hex").slice(0, 16)
+  // The user is part of the key as well as the project. `tmpdir()` is shared
+  // on a multi-user box, and two people with the same checkout would otherwise
+  // derive one path that only the first of them can own.
+  const user = process.getuid?.() ?? process.env.USERNAME ?? process.env.USER ?? ""
+  const key = createHash("sha1")
+    .update(`${user}\u0000${resolve(root)}`)
+    .digest("hex")
+    .slice(0, 16)
 
   // Windows has no unix sockets, but `node:net` speaks named pipes through the
   // same API, and a pipe name is not a path so the length cap does not apply.
@@ -21,6 +28,14 @@ export function controlPath(root: string): string {
     ? String.raw`\\.\pipe\slua-${key}`
     : join(tmpdir(), `slua-${key}.sock`)
 }
+
+/**
+ * The most one unterminated frame may buffer before the peer is hung up on.
+ *
+ * A `control.logs` answer carrying the record cap is the largest thing that
+ * legitimately crosses this socket, and it is orders of magnitude under this.
+ */
+const MAX_FRAME_BYTES = 16 * 1024 * 1024
 
 /**
  * Frames a byte stream into the one-object-per-message the peer expects.
@@ -59,6 +74,16 @@ export function socketTransport(socket: Socket): Transport {
       buffer = buffer.slice(end + 1)
 
       if (line.trim() !== "") transport.onmessage?.(line)
+    }
+
+    // A peer that never sends a newline would grow this string until the
+    // process runs out of memory. No real message comes near the cap, so one
+    // that does is a peer to hang up on rather than a frame to wait for.
+    if (buffer.length > MAX_FRAME_BYTES) {
+      buffer = ""
+
+      transport.onerror?.(new Error(`control frame exceeded ${MAX_FRAME_BYTES} bytes`))
+      socket.destroy()
     }
   })
 

--- a/packages/viewer-client/src/control/socket.ts
+++ b/packages/viewer-client/src/control/socket.ts
@@ -1,0 +1,69 @@
+import { createHash } from "node:crypto"
+import type { Socket } from "node:net"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+import type { Transport } from "../protocol/jsonrpc.js"
+
+/**
+ * Where a project's control socket lives.
+ *
+ * In tmpdir keyed by a hash of the project root, not in `.slua/`: macOS caps
+ * a unix socket path at about 104 bytes and a deep project path blows that on
+ * its own. The real path is recorded in `.slua/session.json`, so a client
+ * still only has to read one file to find it.
+ */
+export function controlPath(root: string): string {
+  const key = createHash("sha1").update(resolve(root)).digest("hex").slice(0, 16)
+
+  // Windows has no unix sockets, but `node:net` speaks named pipes through the
+  // same API, and a pipe name is not a path so the length cap does not apply.
+  return process.platform === "win32"
+    ? String.raw`\\.\pipe\slua-${key}`
+    : join(tmpdir(), `slua-${key}.sock`)
+}
+
+/**
+ * Frames a byte stream into the one-object-per-message the peer expects.
+ *
+ * A WebSocket hands over message boundaries; a socket hands over bytes. JSON
+ * never contains a raw newline once encoded, so a newline is a free frame
+ * separator here.
+ */
+export function socketTransport(socket: Socket): Transport {
+  const transport: Transport = {
+    send: (data) => {
+      socket.write(`${data}\n`)
+    },
+    close: () => {
+      socket.end()
+    },
+    onmessage: null,
+    onclose: null,
+    onerror: null,
+  }
+
+  let buffer = ""
+
+  socket.setEncoding("utf8")
+
+  socket.on("data", (chunk: string) => {
+    buffer += chunk
+
+    for (;;) {
+      const end = buffer.indexOf("\n")
+
+      if (end < 0) break
+
+      const line = buffer.slice(0, end)
+
+      buffer = buffer.slice(end + 1)
+
+      if (line.trim() !== "") transport.onmessage?.(line)
+    }
+  })
+
+  socket.on("close", () => transport.onclose?.())
+  socket.on("error", (error) => transport.onerror?.(error))
+
+  return transport
+}

--- a/packages/viewer-client/src/protocol/case.test.ts
+++ b/packages/viewer-client/src/protocol/case.test.ts
@@ -69,7 +69,7 @@ describe("toSnake", () => {
 
   it("still converts anything indistinguishable from one of our fields", () => {
     // A bare lowerCamelCase key cannot be told apart from a field name, so it
-    // is converted. That is the irreducible edge of a generic transform.
+    // is converted. That is the edge a generic transform cannot avoid.
     expect(toSnake({ llSay: 1 })).toEqual({ ll_say: 1 })
   })
 })

--- a/packages/viewer-client/src/protocol/case.ts
+++ b/packages/viewer-client/src/protocol/case.ts
@@ -5,12 +5,11 @@
  * and the conversion happens once at the JSON-RPC boundary rather than at each
  * call site, so no typed message has to carry both spellings.
  *
- * The transform is generic, which means it also reaches keys inside payloads
- * we do not own: the `params` of an `editor.*` command, and whatever a command
- * handler returns. So it only touches keys that are shaped like protocol field
- * names. A key holding data instead, an inventory item called `Main` or an
- * object called `Door Control`, is left exactly as it is. Values are never
- * touched at all.
+ * The transform is generic, so it also reaches keys inside payloads we do not
+ * own: the `params` of an `editor.*` command, and whatever a command handler
+ * returns. It therefore only touches keys shaped like protocol field names. A
+ * key holding data, an inventory item called `Main` or an object called `Door
+ * Control`, is left alone, and values are never touched.
  */
 
 /** A wire field name: lowercase, underscore separated. */
@@ -57,12 +56,10 @@ function mapKeys(value: unknown, convert: (key: string) => string): unknown {
   return result
 }
 
-/** Wire payload to the camelCase shape this package exposes. */
 export function toCamel<T = unknown>(value: unknown): T {
   return mapKeys(value, camelKey) as T
 }
 
-/** Our camelCase shape back to the snake_case the viewer expects. */
 export function toSnake<T = unknown>(value: unknown): T {
   return mapKeys(value, snakeKey) as T
 }

--- a/packages/viewer-client/src/protocol/jsonrpc.ts
+++ b/packages/viewer-client/src/protocol/jsonrpc.ts
@@ -34,9 +34,9 @@ const JSONRPC_VERSION = "2.0"
 /**
  * JSON-RPC 2.0 over a text transport: one object per frame, no batching.
  *
- * This is a peer rather than a client — the viewer calls us as often as we
- * call it (`session.handshake`, `session.ping`, `command.execute`), so both
- * directions are first class.
+ * A peer rather than a client. The viewer calls us as often as we call it
+ * (`session.handshake`, `session.ping`, `command.execute`), so both directions
+ * are first class.
  */
 export class JsonRpcPeer {
   private readonly transport: Transport
@@ -103,7 +103,7 @@ export class JsonRpcPeer {
       throw new ConnectionClosedError()
     }
 
-    // Notifications must omit `id` entirely — a null id reads as a request to
+    // Notifications must omit `id` entirely. A null id reads as a request to
     // some implementations, including sl-vscode-plugin's.
     this.transport.send(
       JSON.stringify({ jsonrpc: JSONRPC_VERSION, method, params: toSnake(params) }),

--- a/packages/viewer-client/src/protocol/peer.test.ts
+++ b/packages/viewer-client/src/protocol/peer.test.ts
@@ -75,7 +75,7 @@ async function completeHandshake(transport: FakeTransport, challenge?: string) {
 
 describe("buildHandshakeResponse", () => {
   it("echoes the challenge file contents verbatim", async () => {
-    // Whatever the file holds goes back untouched; the viewer parses it.
+    // Whatever the file holds goes back untouched. The viewer parses it.
     const path = await challengeFile("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\n")
     const response = await buildHandshakeResponse(handshake(path))
 

--- a/packages/viewer-client/src/readme.test.ts
+++ b/packages/viewer-client/src/readme.test.ts
@@ -6,8 +6,8 @@ import ts from "typescript"
 /**
  * Typechecks the TypeScript examples in the README.
  *
- * Documented code drifts silently as the API changes, and a broken example is
- * worse than none: it costs a reader more to debug than to write from scratch.
+ * Documented code drifts silently as the API changes, and a broken example
+ * costs a reader more to debug than writing one from scratch would.
  */
 const PACKAGE_ROOT = dirname(import.meta.dir)
 const README = join(PACKAGE_ROOT, "README.md")

--- a/packages/viewer-client/src/sourcemap.ts
+++ b/packages/viewer-client/src/sourcemap.ts
@@ -9,8 +9,8 @@ const CHAR_TO_INT = new Map<string, number>([...BASE64].map((char, index) => [ch
 /**
  * Decodes one line's worth of base64 VLQ segments.
  *
- * Rolled by hand rather than pulled from a dependency: we only ever need line
- * granularity, so this is a few dozen lines against a whole package.
+ * Rolled by hand rather than pulled from a dependency. Line granularity is
+ * all we need, so this is a few dozen lines against a whole package.
  */
 function decodeSegments(line: string): number[][] {
   const segments: number[][] = []
@@ -127,8 +127,8 @@ export class SourceMap {
         // compiler's line number refers to.
         const source = sources[sourceIndex]
 
-        // A segment pointing outside `sources` is no better than no mapping:
-        // an empty path would be reported as the error's file and hide the
+        // A segment pointing outside `sources` is no better than no mapping.
+        // An empty path would be reported as the error's file and hide the
         // fallback to the pushed file.
         if (source !== undefined && generatedColumn < bestColumn) {
           bestColumn = generatedColumn
@@ -176,8 +176,8 @@ export function resolveExistingSource(source: string, mapDir: string): string {
 /**
  * Loads the map TSTL writes beside an emitted file (`<output>.map`).
  *
- * Returns undefined when there is no map, or it cannot be read or parsed —
- * callers fall back to reporting raw generated line numbers.
+ * Returns undefined when there is no map, or it cannot be read or parsed.
+ * Callers then report raw generated line numbers.
  */
 export async function loadSourceMapFor(filePath: string): Promise<SourceMap | undefined> {
   const mapPath = `${filePath}.map`

--- a/packages/viewer-client/src/state.test.ts
+++ b/packages/viewer-client/src/state.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, describe, expect, it } from "bun:test"
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { LOG_FILE, openState, readSession, stateDirectory } from "./state"
+
+const made: string[] = []
+
+afterEach(async () => {
+  for (const dir of made.splice(0)) await rm(dir, { recursive: true, force: true })
+})
+
+async function root(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "slua-state-"))
+
+  made.push(dir)
+
+  return dir
+}
+
+describe("openState", () => {
+  it("writes a session file and takes it away again on close", async () => {
+    const dir = await root()
+    const state = await openState(dir, { port: 9020, root: dir })
+
+    expect(await readSession(dir)).toMatchObject({ pid: process.pid, port: 9020, root: dir })
+
+    await state.close()
+
+    // A session file that outlives its session points at a pid that may since
+    // have become something else.
+    expect(await readSession(dir)).toBeUndefined()
+  })
+
+  it("appends one JSON object per line, in order", async () => {
+    const dir = await root()
+    const state = await openState(dir, { port: 9020, root: dir })
+
+    state.append({ kind: "runtime", seq: 1 })
+    state.append({ kind: "push", target: "main" })
+
+    await state.flush()
+
+    const lines = (await readFile(join(stateDirectory(dir), LOG_FILE), "utf8"))
+      .split("\n")
+      .filter((line) => line !== "")
+
+    expect(lines.map((line) => JSON.parse(line))).toEqual([
+      { kind: "runtime", seq: 1 },
+      { kind: "push", target: "main" },
+    ])
+
+    await state.close()
+  })
+
+  it("rotates at the size cap, keeping one previous file", async () => {
+    const dir = await root()
+    const state = await openState(dir, { port: 9020, root: dir }, { maxBytes: 200 })
+
+    for (let index = 0; index < 20; index++) {
+      state.append({ kind: "runtime", seq: index, message: "x".repeat(20) })
+    }
+
+    await state.flush()
+
+    const logPath = join(stateDirectory(dir), LOG_FILE)
+    const current = await readFile(logPath, "utf8")
+    const previous = await readFile(`${logPath}.1`, "utf8")
+
+    expect(current.length).toBeLessThanOrEqual(200)
+    expect(previous.length).toBeGreaterThan(0)
+
+    // Whatever survived is still readable line by line, which is the whole
+    // point of the format.
+    for (const entry of `${previous}${current}`.split("\n").filter((text) => text !== "")) {
+      expect(() => JSON.parse(entry)).not.toThrow()
+    }
+
+    await state.close()
+  })
+
+  it("reports an unwritable sink once rather than per record", async () => {
+    const dir = await root()
+    const state = await openState(dir, { port: 9020, root: dir })
+    const errors: string[] = []
+
+    await state.close()
+
+    // Something in the way of the log file, so every write fails.
+    await rm(join(stateDirectory(dir), LOG_FILE), { force: true })
+
+    const blocked = await openState(
+      dir,
+      { port: 9020, root: dir },
+      { onError: (error) => errors.push(error.message) },
+    )
+
+    await rm(stateDirectory(dir), { recursive: true, force: true })
+    await writeFile(stateDirectory(dir), "not a directory", "utf8")
+
+    blocked.append({ kind: "runtime", seq: 1 })
+    blocked.append({ kind: "runtime", seq: 2 })
+
+    await blocked.flush()
+
+    expect(errors.length).toBe(1)
+  })
+})

--- a/packages/viewer-client/src/state.test.ts
+++ b/packages/viewer-client/src/state.test.ts
@@ -23,6 +23,12 @@ describe("openState", () => {
     const dir = await root()
     const state = await openState(dir, { port: 9020, root: dir })
 
+    // Held back until the control socket is this session's, so a start that
+    // loses that race never describes itself.
+    expect(await readSession(dir)).toBeUndefined()
+
+    await state.announce()
+
     expect(await readSession(dir)).toMatchObject({ pid: process.pid, port: 9020, root: dir })
 
     await state.close()
@@ -36,9 +42,13 @@ describe("openState", () => {
     const dir = await root()
     const first = await openState(dir, { port: 9020, root: dir })
 
+    await first.announce()
+
     // Teardown releases the control socket before the state, so the session
     // that replaced this one can already be up.
     const second = await openState(dir, { port: 9021, root: dir })
+
+    await second.announce()
 
     await first.close()
 

--- a/packages/viewer-client/src/state.test.ts
+++ b/packages/viewer-client/src/state.test.ts
@@ -70,8 +70,8 @@ describe("openState", () => {
     expect(current.length).toBeLessThanOrEqual(200)
     expect(previous.length).toBeGreaterThan(0)
 
-    // Whatever survived is still readable line by line, which is the whole
-    // point of the format.
+    // Whatever survived is still readable line by line, which is the point of
+    // the format.
     for (const entry of `${previous}${current}`.split("\n").filter((text) => text !== "")) {
       expect(() => JSON.parse(entry)).not.toThrow()
     }

--- a/packages/viewer-client/src/state.test.ts
+++ b/packages/viewer-client/src/state.test.ts
@@ -32,6 +32,23 @@ describe("openState", () => {
     expect(await readSession(dir)).toBeUndefined()
   })
 
+  it("leaves the session file a later session wrote", async () => {
+    const dir = await root()
+    const first = await openState(dir, { port: 9020, root: dir })
+
+    // Teardown releases the control socket before the state, so the session
+    // that replaced this one can already be up.
+    const second = await openState(dir, { port: 9021, root: dir })
+
+    await first.close()
+
+    expect(await readSession(dir)).toMatchObject({ port: 9021 })
+
+    await second.close()
+
+    expect(await readSession(dir)).toBeUndefined()
+  })
+
   it("appends one JSON object per line, in order", async () => {
     const dir = await root()
     const state = await openState(dir, { port: 9020, root: dir })

--- a/packages/viewer-client/src/state.ts
+++ b/packages/viewer-client/src/state.ts
@@ -14,7 +14,7 @@ export const LOG_MAX_BYTES = 5 * 1024 * 1024
 /**
  * What a running `connect` says about itself.
  *
- * Never trusted on its own: a pid file outlives the process that wrote it, so
+ * Never trusted on its own. A pid file outlives the process that wrote it, so
  * liveness is decided by connecting to the socket, not by reading this.
  */
 export interface SessionInfo {
@@ -34,7 +34,6 @@ export interface SessionState {
   readonly logPath: string
   /** Appends one record. Ordering is preserved; failures are reported once. */
   append(record: Record<string, unknown>): void
-  /** Waits for everything appended so far to reach the disk. */
   flush(): Promise<void>
   /** Flushes, then forgets the session, so a stale file never outlives it. */
   close(): Promise<void>
@@ -54,8 +53,7 @@ export async function readSession(root: string): Promise<SessionInfo | undefined
   try {
     return JSON.parse(await readFile(join(stateDirectory(root), SESSION_FILE), "utf8"))
   } catch {
-    // Missing, or half-written by a session that died mid-write. Either way
-    // there is nothing here to trust.
+    // Missing, or half-written by a session that died. Nothing to trust.
     return undefined
   }
 }
@@ -70,9 +68,9 @@ export interface StateOptions {
 /**
  * Opens `.slua/` for a session, writing its session file and a log sink.
  *
- * The sink is what an agent can read with no integration at all. `tail -n 100
+ * The sink is what an agent reads with no integration at all. `tail -n 100
  * .slua/logs.jsonl` needs nothing from us, and it survives `connect` crashing,
- * which is exactly when its output is worth reading.
+ * which is when its output is worth reading.
  */
 export async function openState(
   root: string,
@@ -92,7 +90,12 @@ export async function openState(
     ...info,
   }
 
-  await writeFile(sessionPath, `${JSON.stringify(session, null, 2)}\n`, "utf8")
+  // Written aside and renamed over. A reader that opens this file mid-write
+  // would otherwise parse half a document and conclude there is no session.
+  const pending = `${sessionPath}.${process.pid}.tmp`
+
+  await writeFile(pending, `${JSON.stringify(session, null, 2)}\n`, "utf8")
+  await rename(pending, sessionPath)
 
   let size = await stat(logPath)
     .then((stats) => stats.size)
@@ -104,9 +107,13 @@ export async function openState(
   let reported = false
 
   const write = async (line: string) => {
+    // Bytes, not characters. `stat` counts what is on disk, and one emoji in
+    // a log line is four of them, so a character count drifts under the cap.
+    const bytes = Buffer.byteLength(line, "utf8")
+
     // Rotated before the write rather than after, so the cap is a ceiling
     // rather than a line it is allowed to cross once.
-    if (size > 0 && size + line.length > maxBytes) {
+    if (size > 0 && size + bytes > maxBytes) {
       await rename(logPath, `${logPath}.1`)
 
       size = 0
@@ -114,7 +121,7 @@ export async function openState(
 
     await appendFile(logPath, line, "utf8")
 
-    size += line.length
+    size += bytes
   }
 
   return {
@@ -124,8 +131,8 @@ export async function openState(
     append(record) {
       const line = `${JSON.stringify(record)}\n`
 
-      // Chained rather than awaited by the caller: a log sink must not be able
-      // to slow down, or reorder, the stream it is recording.
+      // Chained rather than awaited by the caller. A log sink must not slow
+      // down, or reorder, the stream it is recording.
       chain = chain.then(
         () => write(line),
         () => write(line),
@@ -147,8 +154,8 @@ export async function openState(
     async close() {
       await chain
 
-      // A session file that outlives its session is worse than none: it points
-      // at a pid that may since have become something else entirely.
+      // A session file that outlives its session is worse than none. It points
+      // at a pid that may since have become something else.
       await rm(sessionPath, { force: true })
     },
   }

--- a/packages/viewer-client/src/state.ts
+++ b/packages/viewer-client/src/state.ts
@@ -32,6 +32,8 @@ export interface SessionInfo {
 export interface SessionState {
   readonly directory: string
   readonly logPath: string
+  /** Writes the session file, once the socket it names is this session's. */
+  announce(): Promise<void>
   /** Appends one record. Ordering is preserved; failures are reported once. */
   append(record: Record<string, unknown>): void
   flush(): Promise<void>
@@ -66,7 +68,7 @@ export interface StateOptions {
 }
 
 /**
- * Opens `.slua/` for a session, writing its session file and a log sink.
+ * Opens `.slua/` for a session, with a log sink and a session file to write.
  *
  * The sink is what an agent reads with no integration at all. `tail -n 100
  * .slua/logs.jsonl` needs nothing from us, and it survives `connect` crashing,
@@ -90,13 +92,18 @@ export async function openState(
     ...info,
   }
 
-  // Written aside and renamed over. A reader that opens this file mid-write
-  // would otherwise parse half a document and conclude there is no session.
-  const pending = `${sessionPath}.${process.pid}.tmp`
   const document = `${JSON.stringify(session, null, 2)}\n`
 
-  await writeFile(pending, document, "utf8")
-  await rename(pending, sessionPath)
+  /**
+   * Written aside and renamed over. A reader that opens this file mid-write
+   * would otherwise parse half a document and conclude there is no session.
+   */
+  const announce = async () => {
+    const pending = `${sessionPath}.${process.pid}.tmp`
+
+    await writeFile(pending, document, "utf8")
+    await rename(pending, sessionPath)
+  }
 
   /** Whether the file on disk is still the one this session wrote, byte for byte. */
   const owned = async () =>
@@ -132,6 +139,7 @@ export async function openState(
   return {
     directory,
     logPath,
+    announce,
 
     append(record) {
       const line = `${JSON.stringify(record)}\n`

--- a/packages/viewer-client/src/state.ts
+++ b/packages/viewer-client/src/state.ts
@@ -35,7 +35,7 @@ export interface SessionState {
   /** Appends one record. Ordering is preserved; failures are reported once. */
   append(record: Record<string, unknown>): void
   flush(): Promise<void>
-  /** Flushes, then forgets the session, so a stale file never outlives it. */
+  /** Forgets the session, then flushes, so a stale file never outlives it. */
   close(): Promise<void>
 }
 
@@ -93,9 +93,14 @@ export async function openState(
   // Written aside and renamed over. A reader that opens this file mid-write
   // would otherwise parse half a document and conclude there is no session.
   const pending = `${sessionPath}.${process.pid}.tmp`
+  const document = `${JSON.stringify(session, null, 2)}\n`
 
-  await writeFile(pending, `${JSON.stringify(session, null, 2)}\n`, "utf8")
+  await writeFile(pending, document, "utf8")
   await rename(pending, sessionPath)
+
+  /** Whether the file on disk is still the one this session wrote, byte for byte. */
+  const owned = async () =>
+    (await readFile(sessionPath, "utf8").catch(() => undefined)) === document
 
   let size = await stat(logPath)
     .then((stats) => stats.size)
@@ -152,11 +157,12 @@ export async function openState(
     },
 
     async close() {
-      await chain
+      // Teardown releases the control socket first, so a replacement session
+      // may already have written its own file. Deleting that one would hide a
+      // session that is running.
+      if (await owned()) await rm(sessionPath, { force: true })
 
-      // A session file that outlives its session is worse than none. It points
-      // at a pid that may since have become something else.
-      await rm(sessionPath, { force: true })
+      await chain
     },
   }
 }

--- a/packages/viewer-client/src/state.ts
+++ b/packages/viewer-client/src/state.ts
@@ -1,0 +1,155 @@
+import { appendFile, mkdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises"
+import { createRequire } from "node:module"
+import { join } from "node:path"
+
+/** Where a session's state lives, beside the `slua.json` it belongs to. */
+export const STATE_DIRECTORY = ".slua"
+
+export const SESSION_FILE = "session.json"
+export const LOG_FILE = "logs.jsonl"
+
+/** Rotated at this size, keeping one previous file. */
+export const LOG_MAX_BYTES = 5 * 1024 * 1024
+
+/**
+ * What a running `connect` says about itself.
+ *
+ * Never trusted on its own: a pid file outlives the process that wrote it, so
+ * liveness is decided by connecting to the socket, not by reading this.
+ */
+export interface SessionInfo {
+  pid: number
+  /** Control socket path. Absent until the socket is listening. */
+  socket?: string
+  /** The viewer port the session is connected to. */
+  port: number
+  /** The project root, which is the directory holding `slua.json`. */
+  root: string
+  version: string
+  startedAt: string
+}
+
+export interface SessionState {
+  readonly directory: string
+  readonly logPath: string
+  /** Appends one record. Ordering is preserved; failures are reported once. */
+  append(record: Record<string, unknown>): void
+  /** Waits for everything appended so far to reach the disk. */
+  flush(): Promise<void>
+  /** Flushes, then forgets the session, so a stale file never outlives it. */
+  close(): Promise<void>
+}
+
+export function stateDirectory(root: string): string {
+  return join(root, STATE_DIRECTORY)
+}
+
+/** The version of the CLI writing the state, so a mismatch can be reported. */
+export function cliVersion(): string {
+  return createRequire(import.meta.url)("../package.json").version
+}
+
+/** Reads a project's session file, or nothing when no session wrote one. */
+export async function readSession(root: string): Promise<SessionInfo | undefined> {
+  try {
+    return JSON.parse(await readFile(join(stateDirectory(root), SESSION_FILE), "utf8"))
+  } catch {
+    // Missing, or half-written by a session that died mid-write. Either way
+    // there is nothing here to trust.
+    return undefined
+  }
+}
+
+export interface StateOptions {
+  /** Told once when the sink cannot write, rather than on every record. */
+  onError?: (error: Error) => void
+  /** Overrides the rotation size. Mostly here so a test can reach it. */
+  maxBytes?: number
+}
+
+/**
+ * Opens `.slua/` for a session, writing its session file and a log sink.
+ *
+ * The sink is what an agent can read with no integration at all. `tail -n 100
+ * .slua/logs.jsonl` needs nothing from us, and it survives `connect` crashing,
+ * which is exactly when its output is worth reading.
+ */
+export async function openState(
+  root: string,
+  info: Omit<SessionInfo, "pid" | "version" | "startedAt"> & Partial<SessionInfo>,
+  options: StateOptions = {},
+): Promise<SessionState> {
+  const directory = stateDirectory(root)
+  const logPath = join(directory, LOG_FILE)
+  const sessionPath = join(directory, SESSION_FILE)
+
+  await mkdir(directory, { recursive: true })
+
+  const session: SessionInfo = {
+    pid: process.pid,
+    version: cliVersion(),
+    startedAt: new Date().toISOString(),
+    ...info,
+  }
+
+  await writeFile(sessionPath, `${JSON.stringify(session, null, 2)}\n`, "utf8")
+
+  let size = await stat(logPath)
+    .then((stats) => stats.size)
+    .catch(() => 0)
+
+  const maxBytes = options.maxBytes ?? LOG_MAX_BYTES
+
+  let chain: Promise<void> = Promise.resolve()
+  let reported = false
+
+  const write = async (line: string) => {
+    // Rotated before the write rather than after, so the cap is a ceiling
+    // rather than a line it is allowed to cross once.
+    if (size > 0 && size + line.length > maxBytes) {
+      await rename(logPath, `${logPath}.1`)
+
+      size = 0
+    }
+
+    await appendFile(logPath, line, "utf8")
+
+    size += line.length
+  }
+
+  return {
+    directory,
+    logPath,
+
+    append(record) {
+      const line = `${JSON.stringify(record)}\n`
+
+      // Chained rather than awaited by the caller: a log sink must not be able
+      // to slow down, or reorder, the stream it is recording.
+      chain = chain.then(
+        () => write(line),
+        () => write(line),
+      )
+
+      chain = chain.catch((error: unknown) => {
+        if (reported) return
+
+        reported = true
+
+        options.onError?.(error instanceof Error ? error : new Error(String(error)))
+      })
+    },
+
+    flush() {
+      return chain
+    },
+
+    async close() {
+      await chain
+
+      // A session file that outlives its session is worse than none: it points
+      // at a pid that may since have become something else entirely.
+      await rm(sessionPath, { force: true })
+    },
+  }
+}

--- a/packages/viewer-client/src/targets.test.ts
+++ b/packages/viewer-client/src/targets.test.ts
@@ -268,7 +268,7 @@ describe("readHeaderTagsFor", () => {
   })
 
   it("treats a hand-written script as its own source", async () => {
-    // An .lsl file has no source map; the header is right there in the file.
+    // An .lsl file has no source map. The header is right there in the file.
     const dir = await mkdtemp(join(tmpdir(), "slua-hdr-"))
     const file = join(dir, "door.lsl")
 

--- a/packages/viewer-client/src/targets.ts
+++ b/packages/viewer-client/src/targets.ts
@@ -11,7 +11,6 @@ import { loadSourceMapFor } from "./sourcemap.js"
 
 const VM_VALUES: ScriptVM[] = ["luau", "mono", "lsl2"]
 
-/** Everything needed to deploy one built script. */
 export interface Target {
   name: string
   /** Absolute path to the built output. */
@@ -92,7 +91,7 @@ export interface HeaderTagOptions {
   /**
    * Skip unrecognised `@slua-*` tags instead of failing.
    *
-   * Set when sweeping the inputs behind a bundle: those include vendored code
+   * Set when sweeping the inputs behind a bundle. Those include vendored code
    * nobody here wrote, and one stray tag in a dependency should not stop a
    * push.
    */
@@ -184,7 +183,7 @@ async function tagsIn(
 /**
  * Reads the header tags for a file about to be pushed.
  *
- * For a compiled bundle that means the sources behind it; for a hand-written
+ * For a compiled bundle that means the sources behind it. For a hand-written
  * script, LSL or otherwise, the file is its own source.
  */
 export async function readHeaderTagsFor(file: string): Promise<PartialTarget | undefined> {
@@ -308,7 +307,7 @@ export interface ResolveOptions {
 /**
  * Combines the layers into a deployable target.
  *
- * Precedence is command line, then config, then the source header: the header
+ * Precedence is command line, then config, then the source header. The header
  * is the default a script ships with, and config retargets it per environment
  * without touching the source.
  */

--- a/packages/viewer-client/src/watch.test.ts
+++ b/packages/viewer-client/src/watch.test.ts
@@ -6,6 +6,9 @@ import { watchTargets, type WatchTarget, type Watcher } from "./watch"
 
 const DEBOUNCE_MS = 40
 
+/** The leading-edge window, which has to cover fs.watch delivery jitter. */
+const LEADING_DEBOUNCE_MS = 500
+
 /** Long enough for fs.watch to deliver and the window to close after it. */
 const SETTLE_MS = 250
 
@@ -18,7 +21,7 @@ const open: Watcher[] = []
 const made: string[] = []
 
 afterEach(async () => {
-  for (const watcher of open.splice(0)) watcher.close()
+  for (const watcher of open.splice(0)) await watcher.close()
 
   for (const dir of made.splice(0)) await rm(dir, { recursive: true, force: true })
 })
@@ -38,10 +41,9 @@ async function project(): Promise<{ dir: string; target: WatchTarget }> {
 /**
  * Starts a watcher and waits for it to be armed.
  *
- * A write that lands in the moment between `watch()` returning and the OS
- * actually reporting on the directory is simply not seen, which is a test
- * harness problem rather than a watcher one: real edits come long after the
- * session started.
+ * A write that lands between `watch()` returning and the OS reporting on the
+ * directory is not seen. That is a harness problem rather than a watcher one,
+ * since real edits come long after the session started.
  */
 async function start<T extends WatchTarget>(
   targets: readonly T[],
@@ -103,7 +105,10 @@ describe("watchTargets", () => {
     const { batches, onChange } = collector()
 
     await start([target], onChange, {
-      debounceMs: DEBOUNCE_MS,
+      // Wider than the trailing tests use. The window has to outlast the gap
+      // between the two writes reaching fs.watch, or the second fires a
+      // leading edge of its own and this passes for the wrong reason.
+      debounceMs: LEADING_DEBOUNCE_MS,
       minIntervalMs: 0,
       edge: "leading",
     })

--- a/packages/viewer-client/src/watch.test.ts
+++ b/packages/viewer-client/src/watch.test.ts
@@ -1,0 +1,294 @@
+import { afterEach, describe, expect, it } from "bun:test"
+import { mkdtemp, rename, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { watchTargets, type WatchTarget, type Watcher } from "./watch"
+
+const DEBOUNCE_MS = 40
+
+/** Long enough for fs.watch to deliver and the window to close after it. */
+const SETTLE_MS = 250
+
+/** Long enough for a freshly installed fs.watch to be armed. */
+const ARM_MS = 100
+
+const sleep = (ms: number) => new Promise((done) => setTimeout(done, ms))
+
+const open: Watcher[] = []
+const made: string[] = []
+
+afterEach(async () => {
+  for (const watcher of open.splice(0)) watcher.close()
+
+  for (const dir of made.splice(0)) await rm(dir, { recursive: true, force: true })
+})
+
+async function project(): Promise<{ dir: string; target: WatchTarget }> {
+  const dir = await mkdtemp(join(tmpdir(), "slua-watch-"))
+
+  made.push(dir)
+
+  const file = join(dir, "main.slua")
+
+  await writeFile(file, "-- one\n", "utf8")
+
+  return { dir, target: { name: "main", file } }
+}
+
+/**
+ * Starts a watcher and waits for it to be armed.
+ *
+ * A write that lands in the moment between `watch()` returning and the OS
+ * actually reporting on the directory is simply not seen, which is a test
+ * harness problem rather than a watcher one: real edits come long after the
+ * session started.
+ */
+async function start<T extends WatchTarget>(
+  targets: readonly T[],
+  onChange: (changed: T[]) => Promise<void>,
+  options: Parameters<typeof watchTargets<T>>[2],
+): Promise<Watcher> {
+  const watcher = watchTargets(targets, onChange, options)
+
+  open.push(watcher)
+
+  await sleep(ARM_MS)
+
+  return watcher
+}
+
+function collector() {
+  const batches: string[][] = []
+
+  return {
+    batches,
+    onChange: async (changed: WatchTarget[]) => {
+      batches.push(changed.map((target) => target.name))
+    },
+  }
+}
+
+/**
+ * Waits for something to have happened, rather than for a fixed time.
+ *
+ * fs.watch delivery is not prompt under load, and a test that sleeps for a
+ * guess fails on a busy machine rather than on a broken watcher.
+ */
+async function until(check: () => boolean, timeoutMs = 10_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+
+  while (!check() && Date.now() < deadline) await sleep(10)
+}
+
+describe("watchTargets", () => {
+  it("collapses a burst of writes into one push", async () => {
+    const { target } = await project()
+    const { batches, onChange } = collector()
+
+    await start([target], onChange, { debounceMs: DEBOUNCE_MS, minIntervalMs: 0 })
+
+    for (const line of ["two", "three", "four"]) {
+      await writeFile(target.file, `-- ${line}\n`, "utf8")
+      await sleep(5)
+    }
+
+    await until(() => batches.length > 0)
+    await sleep(SETTLE_MS)
+
+    expect(batches).toEqual([["main"]])
+  })
+
+  it("fires on the first write with a leading edge, and not again in the window", async () => {
+    const { target } = await project()
+    const { batches, onChange } = collector()
+
+    await start([target], onChange, {
+      debounceMs: DEBOUNCE_MS,
+      minIntervalMs: 0,
+      edge: "leading",
+    })
+
+    for (const line of ["two", "three"]) {
+      await writeFile(target.file, `-- ${line}\n`, "utf8")
+      await sleep(5)
+    }
+
+    await until(() => batches.length > 0)
+    await sleep(SETTLE_MS)
+
+    // Leading and trailing together would be two pushes and two restarts here.
+    expect(batches).toEqual([["main"]])
+  })
+
+  it("collapses writes that land during a push into one follow-up", async () => {
+    const { target } = await project()
+    const batches: string[][] = []
+
+    let release: () => void = () => {}
+    const held = new Promise<void>((done) => {
+      release = done
+    })
+
+    let calls = 0
+
+    await start(
+      [target],
+      async (changed) => {
+        batches.push(changed.map((entry) => entry.name))
+
+        // Only the first push is held open, standing in for the upload.
+        if (calls++ === 0) await held
+      },
+      { debounceMs: DEBOUNCE_MS, minIntervalMs: 0 },
+    )
+
+    await writeFile(target.file, "-- two\n", "utf8")
+    await until(() => batches.length > 0)
+
+    expect(batches).toEqual([["main"]])
+
+    for (const line of ["three", "four", "five"]) {
+      await writeFile(target.file, `-- ${line}\n`, "utf8")
+      await sleep(5)
+    }
+
+    await sleep(SETTLE_MS)
+
+    // Still nothing new: an upload cannot be cancelled, so the pending push
+    // waits for it rather than stacking behind it three deep.
+    expect(batches).toEqual([["main"]])
+
+    release()
+
+    await until(() => batches.length > 1)
+
+    expect(batches).toEqual([["main"], ["main"]])
+  })
+
+  it("ignores a rewrite that leaves the content unchanged", async () => {
+    const { target } = await project()
+    const { batches, onChange } = collector()
+
+    await start([target], onChange, { debounceMs: DEBOUNCE_MS, minIntervalMs: 0 })
+
+    await writeFile(target.file, "-- two\n", "utf8")
+    await until(() => batches.length > 0)
+
+    expect(batches).toEqual([["main"]])
+
+    // The no-op rebuild: same bytes, and restarting a running script for it
+    // would be the watcher's own fault.
+    await writeFile(target.file, "-- two\n", "utf8")
+    await sleep(SETTLE_MS)
+
+    expect(batches).toEqual([["main"]])
+  })
+
+  it("defers a second push of the same item, and says so", async () => {
+    const { target } = await project()
+    const { batches, onChange } = collector()
+    const deferrals: number[] = []
+
+    await start([target], onChange, {
+      debounceMs: DEBOUNCE_MS,
+      // Comfortably longer than the settle below, so the deferral is still in
+      // force when it is checked rather than having quietly elapsed.
+      minIntervalMs: 1_000,
+      onDefer: (_targets, waitMs) => deferrals.push(waitMs),
+    })
+
+    await writeFile(target.file, "-- two\n", "utf8")
+    await until(() => batches.length > 0)
+
+    expect(batches).toEqual([["main"]])
+
+    await writeFile(target.file, "-- three\n", "utf8")
+    await until(() => deferrals.length > 0)
+
+    // Held back rather than dropped, and reported, or it looks like a miss.
+    expect(batches).toEqual([["main"]])
+
+    await until(() => batches.length > 1)
+
+    expect(batches).toEqual([["main"], ["main"]])
+  })
+
+  it("notices a file replaced by a rename rather than written in place", async () => {
+    const { dir, target } = await project()
+    const { batches, onChange } = collector()
+
+    await start([target], onChange, { debounceMs: DEBOUNCE_MS, minIntervalMs: 0 })
+
+    // What an editor with atomic saves does, and what a watch on the path
+    // itself stops reporting after.
+    const staging = join(dir, "main.slua.tmp")
+
+    await writeFile(staging, "-- renamed\n", "utf8")
+    await rename(staging, target.file)
+    await until(() => batches.length > 0)
+
+    expect(batches).toEqual([["main"]])
+  })
+
+  it("pushes on trigger without waiting for a window", async () => {
+    const { target } = await project()
+    const { batches, onChange } = collector()
+    const watcher = await start([target], onChange, {
+      debounceMs: 60_000,
+      minIntervalMs: 60_000,
+    })
+
+    await watcher.trigger()
+
+    // An explicit push is a decision, not an inference, so no guard applies.
+    expect(batches).toEqual([["main"]])
+
+    await watcher.trigger(["main"])
+
+    expect(batches).toEqual([["main"], ["main"]])
+  })
+
+  it("keeps watching after a push fails", async () => {
+    const { target } = await project()
+    const errors: string[] = []
+
+    let calls = 0
+
+    await start(
+      [target],
+      async () => {
+        if (calls++ === 0) throw new Error("viewer said no")
+      },
+      {
+        debounceMs: DEBOUNCE_MS,
+        minIntervalMs: 0,
+        onError: (error) => errors.push(error.message),
+      },
+    )
+
+    await writeFile(target.file, "-- two\n", "utf8")
+    await until(() => errors.length > 0)
+
+    await writeFile(target.file, "-- three\n", "utf8")
+    await until(() => calls > 1)
+
+    expect(errors).toEqual(["viewer said no"])
+    expect(calls).toBe(2)
+  })
+
+  it("reports a directory it cannot watch rather than throwing", async () => {
+    const errors: string[] = []
+
+    open.push(
+      watchTargets(
+        [{ name: "main", file: join(tmpdir(), "slua-missing-dir", "main.slua") }],
+        async () => {},
+        {
+          onError: (error) => errors.push(error.message),
+        },
+      ),
+    )
+
+    expect(errors).toEqual([expect.stringContaining("cannot watch")])
+  })
+})

--- a/packages/viewer-client/src/watch.ts
+++ b/packages/viewer-client/src/watch.ts
@@ -1,0 +1,325 @@
+import { createHash } from "node:crypto"
+import { type FSWatcher, readFileSync, watch } from "node:fs"
+import { readFile } from "node:fs/promises"
+import { dirname } from "node:path"
+
+/**
+ * How long a target has to be quiet before it is pushed.
+ *
+ * Every push restarts the script and costs a simulator asset upload, so the
+ * job here is not to notice a change quickly, it is to decide when a burst of
+ * changes has finished. Too short and six small edits become six restarts, too
+ * long and someone waits at a terminal wondering whether it noticed. Restarts
+ * are the more expensive mistake, so this errs long.
+ */
+export const DEBOUNCE_MS = 3_000
+
+/** The floor between two pushes of the same item, whatever the debounce says. */
+export const MIN_INTERVAL_MS = 3_000
+
+/** The parts of a target the watcher needs. `Target` satisfies it. */
+export interface WatchTarget {
+  name: string
+  /** Absolute path to the built output. */
+  file: string
+}
+
+export interface WatchOptions<T extends WatchTarget = WatchTarget> {
+  /**
+   * Whether to watch at all.
+   *
+   * Off still leaves `trigger`, and with it the queue that keeps two saves
+   * from racing against one prim, so a session driven entirely by explicit
+   * pushes goes through exactly the same path as a watched one.
+   */
+  enabled?: boolean
+  debounceMs?: number
+  /**
+   * Which end of the quiet window to fire on.
+   *
+   * Trailing collapses a burst into one push and is the right default. Leading
+   * gives instant feedback but pushes whatever half-finished state the first
+   * write happened to contain. The two together would mean two pushes and two
+   * restarts per burst, which is what this whole module exists to prevent, so
+   * it is deliberately not offered.
+   */
+  edge?: "trailing" | "leading"
+  minIntervalMs?: number
+  /** Told when a change is held back, so silence never reads as a miss. */
+  onDefer?: (targets: T[], waitMs: number) => void
+  onError?: (error: Error) => void
+}
+
+export interface Watcher {
+  /** Pushes now, skipping the debounce. An explicit ask, so no guard applies. */
+  trigger(names?: readonly string[]): Promise<void>
+  close(): void
+}
+
+/** The content of a file, or undefined if it cannot be read right now. */
+async function digestOf(file: string): Promise<string | undefined> {
+  try {
+    return createHash("sha1")
+      .update(await readFile(file))
+      .digest("hex")
+  } catch {
+    // Mid-write, or gone: let the push report it rather than guessing here.
+    return undefined
+  }
+}
+
+/** The same, at startup, where a race with the first change matters more. */
+function digestNow(file: string): string | undefined {
+  try {
+    return createHash("sha1").update(readFileSync(file)).digest("hex")
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Watches built outputs and calls back once a change has settled.
+ *
+ * Deliberately not a compiler: scaffolds already ship a watch build, tstl's
+ * incremental watch beats anything here, and watching the output works for a
+ * hand-written `.lsl` with no build step at all.
+ */
+export function watchTargets<T extends WatchTarget>(
+  targets: readonly T[],
+  onChange: (changed: T[]) => Promise<void>,
+  options: WatchOptions<T> = {},
+): Watcher {
+  const debounceMs = options.debounceMs ?? DEBOUNCE_MS
+  const minIntervalMs = options.minIntervalMs ?? MIN_INTERVAL_MS
+  const leading = options.edge === "leading"
+
+  /** Targets waiting to be pushed. A map, so a burst collapses to one entry. */
+  const ready = new Map<string, T>()
+  const timers = new Map<string, ReturnType<typeof setTimeout>>()
+  /** When the leading edge stops swallowing changes for a target. */
+  const suppressed = new Map<string, number>()
+  const pushedAt = new Map<string, number>()
+
+  /**
+   * The content each target had when we last acted on it.
+   *
+   * Seeded from disk before the first watch is installed, so an event naming
+   * something else in the directory cannot be mistaken for a change to a
+   * target that has not actually moved.
+   */
+  const digests = new Map<string, string>()
+
+  for (const target of targets) {
+    const digest = digestNow(target.file)
+
+    if (digest !== undefined) digests.set(target.name, digest)
+  }
+
+  const watchers: FSWatcher[] = []
+
+  let chain: Promise<void> = Promise.resolve()
+  let retry: ReturnType<typeof setTimeout> | undefined
+  let closed = false
+
+  /**
+   * Runs `fn` after whatever is already running.
+   *
+   * Two saves in flight against one prim is how the viewer's "item not found
+   * in prim inventory" staleness gets worse, and an upload cannot be
+   * cancelled, so work queues behind the one in flight rather than racing it.
+   */
+  const serialise = <R>(fn: () => Promise<R>): Promise<R> => {
+    const run = chain.then(fn, fn)
+
+    chain = run.then(
+      () => {},
+      () => {},
+    )
+
+    return run
+  }
+
+  const remember = async (target: T) => {
+    const digest = await digestOf(target.file)
+
+    if (digest === undefined) digests.delete(target.name)
+    else digests.set(target.name, digest)
+  }
+
+  const run = async (batch: T[]) => {
+    try {
+      await onChange(batch)
+    } catch (error) {
+      // A failed push must not take the watcher down with it; the next save
+      // is the user's next chance to fix it.
+      options.onError?.(error instanceof Error ? error : new Error(String(error)))
+    } finally {
+      // Measured from when the push finished, not when it started: the
+      // interval exists to space out script restarts, and the upload is most
+      // of the time between them.
+      const now = Date.now()
+
+      for (const target of batch) pushedAt.set(target.name, now)
+    }
+  }
+
+  const flush = () =>
+    serialise(async () => {
+      if (closed || ready.size === 0) return
+
+      const now = Date.now()
+      const batch: T[] = []
+      const deferred: T[] = []
+
+      let wait = 0
+
+      // Snapshotted, since the loop deletes from `ready` as it goes and a
+      // change landing while it awaits must not be visited twice.
+      const waiting = [...ready]
+
+      for (const [name, target] of waiting) {
+        const last = pushedAt.get(name)
+
+        if (last !== undefined && now - last < minIntervalMs) {
+          // Left in `ready`, so the retry below picks it up with whatever the
+          // file says by then rather than what it said now.
+          deferred.push(target)
+          wait = Math.max(wait, minIntervalMs - (now - last))
+
+          continue
+        }
+
+        ready.delete(name)
+
+        const digest = await digestOf(target.file)
+
+        // The cheapest guard of the lot, and it catches the no-op rebuild that
+        // would otherwise restart a running script for nothing.
+        if (digest !== undefined && digest === digests.get(name)) continue
+
+        if (digest !== undefined) digests.set(name, digest)
+
+        batch.push(target)
+      }
+
+      if (deferred.length > 0) {
+        options.onDefer?.(deferred, wait)
+
+        clearTimeout(retry)
+
+        retry = setTimeout(() => {
+          retry = undefined
+
+          void flush()
+        }, wait)
+      }
+
+      if (batch.length === 0) return
+
+      await run(batch)
+
+      // Changes that landed while that push was in flight, as one follow-up
+      // rather than one per write. Only after a push actually happened, or a
+      // batch that was entirely deferred would spin here until its retry.
+      if (ready.size > 0 && !closed) void flush()
+    })
+
+  const mark = (target: T) => {
+    if (closed) return
+
+    if (leading) {
+      const now = Date.now()
+
+      if (now < (suppressed.get(target.name) ?? 0)) return
+
+      suppressed.set(target.name, now + debounceMs)
+      ready.set(target.name, target)
+
+      void flush()
+
+      return
+    }
+
+    // Each change pushes the window out, so only the quiet after a burst fires.
+    clearTimeout(timers.get(target.name))
+
+    timers.set(
+      target.name,
+      setTimeout(() => {
+        timers.delete(target.name)
+        ready.set(target.name, target)
+
+        void flush()
+      }, debounceMs),
+    )
+  }
+
+  const byDirectory = new Map<string, T[]>()
+
+  for (const target of targets) {
+    const directory = dirname(target.file)
+
+    byDirectory.set(directory, [...(byDirectory.get(directory) ?? []), target])
+  }
+
+  for (const [directory, watched] of (options.enabled ?? true) ? byDirectory : []) {
+    try {
+      // The directory rather than each file: an editor, or a build, that
+      // writes a temporary file and renames it over the old one leaves a watch
+      // on the path itself reporting nothing ever again.
+      //
+      // Every target in the directory is marked, whatever the event names,
+      // because macOS coalesces a staging write and the rename that follows it
+      // into a single event naming only the staging file. The digest check at
+      // flush time is what decides whether anything moved, so marking a target
+      // that did not costs one file read and nothing else.
+      const watcher = watch(directory, () => {
+        for (const target of watched) mark(target)
+      })
+
+      watcher.on("error", (error) => options.onError?.(error))
+      watchers.push(watcher)
+    } catch (error) {
+      // A build that has not run yet has no output directory to watch.
+      options.onError?.(
+        new Error(
+          `cannot watch ${directory}: ${error instanceof Error ? error.message : String(error)}`,
+        ),
+      )
+    }
+  }
+
+  return {
+    trigger(names) {
+      const wanted =
+        names && names.length > 0
+          ? targets.filter((target) => names.includes(target.name))
+          : targets
+
+      return serialise(async () => {
+        for (const target of wanted) {
+          ready.delete(target.name)
+
+          // Recorded now, so the write that prompted this does not also come
+          // back through the watcher as a change worth pushing.
+          await remember(target)
+        }
+
+        await run([...wanted])
+      })
+    },
+
+    close() {
+      closed = true
+
+      clearTimeout(retry)
+
+      for (const timer of timers.values()) clearTimeout(timer)
+
+      timers.clear()
+      ready.clear()
+
+      for (const watcher of watchers) watcher.close()
+    },
+  }
+}

--- a/packages/viewer-client/src/watch.ts
+++ b/packages/viewer-client/src/watch.ts
@@ -6,11 +6,11 @@ import { dirname } from "node:path"
 /**
  * How long a target has to be quiet before it is pushed.
  *
- * Every push restarts the script and costs a simulator asset upload, so the
- * job here is not to notice a change quickly, it is to decide when a burst of
- * changes has finished. Too short and six small edits become six restarts, too
- * long and someone waits at a terminal wondering whether it noticed. Restarts
- * are the more expensive mistake, so this errs long.
+ * Every push restarts the script and costs an asset upload, so the job is
+ * deciding when a burst of edits has finished, not noticing one quickly. Too
+ * short and six small edits become six restarts. Too long and someone waits at
+ * a terminal wondering whether it noticed. Restarts cost more, so this errs
+ * long.
  */
 export const DEBOUNCE_MS = 3_000
 
@@ -29,8 +29,8 @@ export interface WatchOptions<T extends WatchTarget = WatchTarget> {
    * Whether to watch at all.
    *
    * Off still leaves `trigger`, and with it the queue that keeps two saves
-   * from racing against one prim, so a session driven entirely by explicit
-   * pushes goes through exactly the same path as a watched one.
+   * from racing against one prim, so a session driven by explicit pushes takes
+   * the same path as a watched one.
    */
   enabled?: boolean
   debounceMs?: number
@@ -39,9 +39,8 @@ export interface WatchOptions<T extends WatchTarget = WatchTarget> {
    *
    * Trailing collapses a burst into one push and is the right default. Leading
    * gives instant feedback but pushes whatever half-finished state the first
-   * write happened to contain. The two together would mean two pushes and two
-   * restarts per burst, which is what this whole module exists to prevent, so
-   * it is deliberately not offered.
+   * write held. Both at once would mean two pushes and two restarts per burst,
+   * which is what this module exists to prevent, so it is not offered.
    */
   edge?: "trailing" | "leading"
   minIntervalMs?: number
@@ -53,22 +52,23 @@ export interface WatchOptions<T extends WatchTarget = WatchTarget> {
 export interface Watcher {
   /** Pushes now, skipping the debounce. An explicit ask, so no guard applies. */
   trigger(names?: readonly string[]): Promise<void>
-  close(): void
+  /** Stops watching, once the push already in flight has finished. */
+  close(): Promise<void>
 }
 
-/** The content of a file, or undefined if it cannot be read right now. */
+/** A digest of a file's content, or undefined if it cannot be read now. */
 async function digestOf(file: string): Promise<string | undefined> {
   try {
     return createHash("sha1")
       .update(await readFile(file))
       .digest("hex")
   } catch {
-    // Mid-write, or gone: let the push report it rather than guessing here.
+    // Mid-write, or gone. Let the push report it rather than guess here.
     return undefined
   }
 }
 
-/** The same, at startup, where a race with the first change matters more. */
+/** The same, synchronously, to seed digests before the first watch goes on. */
 function digestNow(file: string): string | undefined {
   try {
     return createHash("sha1").update(readFileSync(file)).digest("hex")
@@ -80,9 +80,9 @@ function digestNow(file: string): string | undefined {
 /**
  * Watches built outputs and calls back once a change has settled.
  *
- * Deliberately not a compiler: scaffolds already ship a watch build, tstl's
- * incremental watch beats anything here, and watching the output works for a
- * hand-written `.lsl` with no build step at all.
+ * Deliberately not a compiler. Scaffolds already ship a watch build, tstl's
+ * incremental watch beats anything here, and watching the output also works
+ * for a hand-written `.lsl` with no build step.
  */
 export function watchTargets<T extends WatchTarget>(
   targets: readonly T[],
@@ -96,7 +96,7 @@ export function watchTargets<T extends WatchTarget>(
   /** Targets waiting to be pushed. A map, so a burst collapses to one entry. */
   const ready = new Map<string, T>()
   const timers = new Map<string, ReturnType<typeof setTimeout>>()
-  /** When the leading edge stops swallowing changes for a target. */
+  /** When the leading edge stops swallowing changes for a target it pushed. */
   const suppressed = new Map<string, number>()
   const pushedAt = new Map<string, number>()
 
@@ -104,8 +104,7 @@ export function watchTargets<T extends WatchTarget>(
    * The content each target had when we last acted on it.
    *
    * Seeded from disk before the first watch is installed, so an event naming
-   * something else in the directory cannot be mistaken for a change to a
-   * target that has not actually moved.
+   * something else in the directory is not mistaken for a change.
    */
   const digests = new Map<string, string>()
 
@@ -126,7 +125,7 @@ export function watchTargets<T extends WatchTarget>(
    *
    * Two saves in flight against one prim is how the viewer's "item not found
    * in prim inventory" staleness gets worse, and an upload cannot be
-   * cancelled, so work queues behind the one in flight rather than racing it.
+   * cancelled, so work queues behind the one in flight.
    */
   const serialise = <R>(fn: () => Promise<R>): Promise<R> => {
     const run = chain.then(fn, fn)
@@ -150,13 +149,13 @@ export function watchTargets<T extends WatchTarget>(
     try {
       await onChange(batch)
     } catch (error) {
-      // A failed push must not take the watcher down with it; the next save
+      // A failed push must not take the watcher down with it. The next save
       // is the user's next chance to fix it.
       options.onError?.(error instanceof Error ? error : new Error(String(error)))
     } finally {
-      // Measured from when the push finished, not when it started: the
-      // interval exists to space out script restarts, and the upload is most
-      // of the time between them.
+      // Measured from when the push finished, not when it started. The
+      // interval spaces out script restarts, and the upload is most of the
+      // time between them.
       const now = Date.now()
 
       for (const target of batch) pushedAt.set(target.name, now)
@@ -199,6 +198,12 @@ export function watchTargets<T extends WatchTarget>(
 
         if (digest !== undefined) digests.set(name, digest)
 
+        // Set here rather than at mark time. The directory watch fires for
+        // anything in the directory, and a window burned by an event that
+        // moved nothing would swallow the write behind it. Only a real push
+        // starts one.
+        if (leading) suppressed.set(name, Date.now() + debounceMs)
+
         batch.push(target)
       }
 
@@ -220,7 +225,7 @@ export function watchTargets<T extends WatchTarget>(
 
       // Changes that landed while that push was in flight, as one follow-up
       // rather than one per write. Only after a push actually happened, or a
-      // batch that was entirely deferred would spin here until its retry.
+      // wholly deferred batch would spin here until its retry.
       if (ready.size > 0 && !closed) void flush()
     })
 
@@ -228,11 +233,8 @@ export function watchTargets<T extends WatchTarget>(
     if (closed) return
 
     if (leading) {
-      const now = Date.now()
+      if (Date.now() < (suppressed.get(target.name) ?? 0)) return
 
-      if (now < (suppressed.get(target.name) ?? 0)) return
-
-      suppressed.set(target.name, now + debounceMs)
       ready.set(target.name, target)
 
       void flush()
@@ -264,15 +266,14 @@ export function watchTargets<T extends WatchTarget>(
 
   for (const [directory, watched] of (options.enabled ?? true) ? byDirectory : []) {
     try {
-      // The directory rather than each file: an editor, or a build, that
-      // writes a temporary file and renames it over the old one leaves a watch
-      // on the path itself reporting nothing ever again.
+      // The directory rather than each file. An editor or a build that writes
+      // a temporary file and renames it over the old one leaves a watch on the
+      // path itself reporting nothing ever again.
       //
-      // Every target in the directory is marked, whatever the event names,
-      // because macOS coalesces a staging write and the rename that follows it
-      // into a single event naming only the staging file. The digest check at
-      // flush time is what decides whether anything moved, so marking a target
-      // that did not costs one file read and nothing else.
+      // Every target in the directory is marked whatever the event names,
+      // because macOS coalesces a staging write and its rename into a single
+      // event naming only the staging file. The digest check at flush time
+      // decides whether anything moved, so a spurious mark costs one read.
       const watcher = watch(directory, () => {
         for (const target of watched) mark(target)
       })
@@ -309,7 +310,7 @@ export function watchTargets<T extends WatchTarget>(
       })
     },
 
-    close() {
+    async close() {
       closed = true
 
       clearTimeout(retry)
@@ -320,6 +321,12 @@ export function watchTargets<T extends WatchTarget>(
       ready.clear()
 
       for (const watcher of watchers) watcher.close()
+
+      // An upload cannot be cancelled, so a push in flight will finish
+      // whatever happens here. Waiting for it puts the session's teardown, log
+      // flush included, after that push rather than under it. `closed` is set
+      // above, so nothing new joins the queue.
+      await chain
     },
   }
 }


### PR DESCRIPTION
More changes for #115.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added persistent development sessions with watching, rebuilding, publishing, reconnecting, and live output.
- Added `status`, `wait`, and `mcp` commands for session monitoring and integrations.
- `push` now displays runtime output with configurable tailing, replay, filtering, source mapping, and JSON output.
- Scaffolded projects now include viewer-based development workflows and ignore session files.

## Bug Fixes
- Improved diagnostic messages by removing unreadable characters and providing useful fallbacks.

## Documentation
- Expanded CLI, library, target, and development workflow documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->